### PR TITLE
Code smell fixes

### DIFF
--- a/binarize.py
+++ b/binarize.py
@@ -23,13 +23,11 @@ from lib import logging
     help="Evaluation mode: the whole dataset will be processed as validation set."
 )
 def main(config: pathlib.Path, override: list[str], eval_mode: bool):
-    import dask
     from preprocessing.api import (
         load_config_for_binarization,
         binarize_datasets,
     )
     from preprocessing.notes_binarizer import NotesBinarizer
-    dask.config.set(scheduler="synchronous")
 
     config = load_config_for_binarization(config, overrides=override)
     if eval_mode:

--- a/deployment/exporter.py
+++ b/deployment/exporter.py
@@ -108,6 +108,30 @@ class Exporter:
         self.dur2bd_path = self.save_dir / "dur2bd.onnx"
         self.bd2dur_path = self.save_dir / "bd2dur.onnx"
 
+    def _export(self, model, args, save_path, input_names, output_names,
+                 dynamic_axes=None, dynamic_shapes=None, kwargs=None):
+        if self.dynamo:
+            program = torch.onnx.export(
+                model, args, None,
+                kwargs=kwargs,
+                input_names=input_names, output_names=output_names,
+                dynamic_shapes=dynamic_shapes,
+                opset_version=self.opset_version, dynamo=True,
+                external_data=False, dump_exported_program=False,
+            )
+            _clear_stacktrace(program)
+            program.save(save_path)
+        else:
+            torch.onnx.export(
+                model, args, save_path,
+                kwargs=kwargs,
+                input_names=input_names, output_names=output_names,
+                dynamic_axes=dynamic_axes,
+                opset_version=self.opset_version, dynamo=False,
+                external_data=False,
+            )
+        _slim_onnx_model(save_path)
+
     def export(self):
         with torch.no_grad():
             self.export_encoder()
@@ -122,75 +146,33 @@ class Exporter:
 
     def export_encoder(self):
         logging.debug("Exporting encoder start.")
-        encoder_wrapper = WrappedEncoderModel(self.model)
-        if self.dynamo:
-            dump_path = None
-            dynamic_axes = None
-            dynamic_shapes = (
-                {
-                    0: "B",
-                    1: "L",
-                },
-                {
-                    0: "B",
-                },
-            )
-        else:
-            dump_path = self.encoder_path
-            dynamic_axes = {
-                "waveform": {
-                    0: "B",
-                    1: "L",
-                },
-                "duration": {
-                    0: "B",
-                },
-                "x_seg": {
-                    0: "B",
-                    1: "T",
-                },
-                "x_est": {
-                    0: "B",
-                    1: "T",
-                },
-                "maskT": {
-                    0: "B",
-                    1: "T",
-                },
-            }
-            dynamic_shapes = None
-        program = torch.onnx.export(
-            encoder_wrapper,
-            (
-                torch.randn(4, 44100),
-                torch.randn(4),
-            ),
-            dump_path,
-            input_names=[
-                "waveform",
-                "duration",
-            ],
-            output_names=[
-                "x_seg",
-                "x_est",
-                "maskT",
-            ],
-            dynamic_axes=dynamic_axes,
-            dynamic_shapes=dynamic_shapes,
-            opset_version=self.opset_version,
-            dynamo=self.dynamo,
-            external_data=False,
-            dump_exported_program=False,
+        self._export(
+            WrappedEncoderModel(self.model),
+            (torch.randn(4, 44100), torch.randn(4)),
+            self.encoder_path,
+            input_names=["waveform", "duration"],
+            output_names=["x_seg", "x_est", "maskT"],
+            dynamic_shapes=({0: "B", 1: "L"}, {0: "B"}),
+            dynamic_axes={
+                "waveform": {0: "B", 1: "L"},
+                "duration": {0: "B"},
+                "x_seg": {0: "B", 1: "T"},
+                "x_est": {0: "B", 1: "T"},
+                "maskT": {0: "B", 1: "T"},
+            },
         )
-        if self.dynamo:
-            _clear_stacktrace(program)
-            program.save(self.encoder_path)
-        _slim_onnx_model(self.encoder_path)
         logging.debug("Exporting encoder done.")
 
     def export_segmenter(self):
         logging.debug("Exporting segmenter start.")
-        segmenter_wrapper = WrappedSegmenterModel(self.model)
+        kwarg_names = []
+        if self.model.model_config.use_languages:
+            kwarg_names.append("language")
+        kwarg_names.append("known_boundaries")
+        if self.model.model_config.mode == "d3pm":
+            kwarg_names.extend(["prev_boundaries", "t"])
+        kwarg_names.extend(["maskT", "threshold", "radius"])
+
         example_kwargs = {
             "language": torch.zeros((4,), dtype=torch.int64),
             "known_boundaries": torch.ones(4, 100, dtype=torch.bool),
@@ -200,159 +182,40 @@ class Exporter:
             "threshold": torch.tensor(0.5, dtype=torch.float32),
             "radius": torch.tensor(2, dtype=torch.int64),
         }
-        dynamic_arg_shapes = {
-            "x_seg": {
-                0: "B",
-                1: "T",
-            },
-        }
-        dynamic_kwarg_shapes = {
-            "language": {
-                0: "B",
-            },
-            "known_boundaries": {
-                0: "B",
-                1: "T",
-            },
-            "prev_boundaries": {
-                0: "B",
-                1: "T",
-            },
-            "t": {
-                0: "B",
-            },
-            "maskT": {
-                0: "B",
-                1: "T",
-            },
+        kwarg_shapes = {
+            "language": {0: "B"},
+            "known_boundaries": {0: "B", 1: "T"},
+            "prev_boundaries": {0: "B", 1: "T"},
+            "t": {0: "B"},
+            "maskT": {0: "B", 1: "T"},
             "threshold": {},
             "radius": {},
         }
-        dynamic_out_shapes = {
-            "boundaries": {
-                0: "B",
-                1: "T",
-            },
-        }
-        input_kwarg_names = []
-        if self.model.model_config.use_languages:
-            input_kwarg_names.append("language")
-        input_kwarg_names.append("known_boundaries")
-        if self.model.model_config.mode == "d3pm":
-            input_kwarg_names.extend([
-                "prev_boundaries",
-                "t",
-            ])
-        input_kwarg_names.extend([
-            "maskT",
-            "threshold",
-            "radius",
-        ])
-        if self.dynamo:
-            dump_path = None
-            dynamic_shapes = {
-                **dynamic_arg_shapes,
-                **{
-                    k: dynamic_kwarg_shapes[k]
-                    for k in input_kwarg_names
-                }
-            }
-            dynamic_axes = None
-        else:
-            dump_path = self.segmenter_path
-            dynamic_shapes = None
-            dynamic_axes = {
-                **dynamic_arg_shapes,
-                **{
-                    k: dynamic_kwarg_shapes[k]
-                    for k in input_kwarg_names
-                },
-                **dynamic_out_shapes,
-            }
-        program = torch.onnx.export(
-            segmenter_wrapper,
+        arg_shapes = {"x_seg": {0: "B", 1: "T"}}
+
+        self._export(
+            WrappedSegmenterModel(self.model),
             torch.randn(4, 100, self.model.model_config.embedding_dim),
-            dump_path,
-            kwargs={
-                k: example_kwargs[k]
-                for k in input_kwarg_names
+            self.segmenter_path,
+            input_names=["x_seg", *kwarg_names],
+            output_names=["boundaries"],
+            kwargs={k: example_kwargs[k] for k in kwarg_names},
+            dynamic_shapes={
+                **arg_shapes,
+                **{k: kwarg_shapes[k] for k in kwarg_names},
             },
-            input_names=[
-                "x_seg",
-                *input_kwarg_names,
-            ],
-            output_names=[
-                "boundaries",
-            ],
-            dynamic_axes=dynamic_axes,
-            dynamic_shapes=dynamic_shapes,
-            opset_version=self.opset_version,
-            dynamo=self.dynamo,
-            external_data=False,
-            dump_exported_program=False,
+            dynamic_axes={
+                **arg_shapes,
+                **{k: kwarg_shapes[k] for k in kwarg_names},
+                "boundaries": {0: "B", 1: "T"},
+            },
         )
-        if self.dynamo:
-            _clear_stacktrace(program)
-            program.save(self.segmenter_path)
-        _slim_onnx_model(self.segmenter_path)
         logging.debug("Exporting segmenter done.")
 
     def export_estimator(self):
         logging.debug("Exporting estimator start.")
-        estimator_wrapper = WrappedEstimatorModel(self.model)
-        if self.dynamo:
-            dump_path = None
-            dynamic_axes = None
-            dynamic_shapes = (
-                {
-                    0: "B",
-                    1: "T",
-                },
-                {
-                    0: "B",
-                    1: "T",
-                },
-                {
-                    0: "B",
-                    1: "T",
-                },
-                {
-                    0: "B",
-                    1: "N",
-                },
-                {},
-            )
-        else:
-            dump_path = self.estimator_path
-            dynamic_axes = {
-                "x_est": {
-                    0: "B",
-                    1: "T",
-                },
-                "boundaries": {
-                    0: "B",
-                    1: "T",
-                },
-                "maskT": {
-                    0: "B",
-                    1: "T",
-                },
-                "maskN": {
-                    0: "B",
-                    1: "N",
-                },
-                "presence": {
-                    0: "B",
-                    1: "N",
-                },
-                "scores": {
-                    0: "B",
-                    1: "N",
-                },
-            }
-            dynamic_shapes = None
-        program = torch.onnx.export(
-            estimator_wrapper,
+        self._export(
+            WrappedEstimatorModel(self.model),
             (
                 torch.randn(4, 100, self.model.model_config.embedding_dim),
                 (torch.arange(0, 100, dtype=torch.int64) % 10 == 0).unsqueeze(0).expand(4, -1),
@@ -360,89 +223,42 @@ class Exporter:
                 torch.ones(4, 10, dtype=torch.bool),
                 torch.tensor(0.5, dtype=torch.float32),
             ),
-            dump_path,
-            input_names=[
-                "x_est",
-                "boundaries",
-                "maskT",
-                "maskN",
-                "threshold",
-            ],
-            output_names=[
-                "presence",
-                "scores",
-            ],
-            dynamic_axes=dynamic_axes,
-            dynamic_shapes=dynamic_shapes,
-            opset_version=self.opset_version,
-            dynamo=self.dynamo,
-            external_data=False,
-            dump_exported_program=False,
+            self.estimator_path,
+            input_names=["x_est", "boundaries", "maskT", "maskN", "threshold"],
+            output_names=["presence", "scores"],
+            dynamic_shapes=(
+                {0: "B", 1: "T"},
+                {0: "B", 1: "T"},
+                {0: "B", 1: "T"},
+                {0: "B", 1: "N"},
+                {},
+            ),
+            dynamic_axes={
+                "x_est": {0: "B", 1: "T"},
+                "boundaries": {0: "B", 1: "T"},
+                "maskT": {0: "B", 1: "T"},
+                "maskN": {0: "B", 1: "N"},
+                "presence": {0: "B", 1: "N"},
+                "scores": {0: "B", 1: "N"},
+            },
         )
-        if self.dynamo:
-            _clear_stacktrace(program)
-            program.save(self.estimator_path)
-        _slim_onnx_model(self.estimator_path)
         logging.debug("Exporting estimator done.")
 
     def export_converters(self):
         logging.debug("Exporting dur2bd start.")
-        dur2bd = Durations2Boundaries(timestep=self.model.timestep)
-        if self.dynamo:
-            dump_path = None
-            dynamic_shapes = (
-                {
-                    0: "B",
-                    1: "N",
-                },
-                {
-                    0: "B",
-                    1: "T",
-                },
-            )
-            dynamic_axes = None
-        else:
-            dump_path = self.dur2bd_path
-            dynamic_shapes = None
-            dynamic_axes = {
-                "durations": {
-                    0: "B",
-                    1: "N",
-                },
-                "maskT": {
-                    0: "B",
-                    1: "T",
-                },
-                "boundaries": {
-                    0: "B",
-                    1: "T",
-                },
-            }
-        program = torch.onnx.export(
-            dur2bd,
-            (
-                torch.rand(4, 10),
-                torch.ones(4, 100, dtype=torch.bool),
-            ),
-            dump_path,
-            input_names=[
-                "durations",
-                "maskT",
-            ],
-            output_names=[
-                "boundaries",
-            ],
-            dynamic_axes=dynamic_axes,
-            dynamic_shapes=dynamic_shapes,
-            opset_version=self.opset_version,
-            dynamo=self.dynamo,
-            external_data=False,
-            dump_exported_program=False,
+        self._export(
+            Durations2Boundaries(timestep=self.model.timestep),
+            (torch.rand(4, 10), torch.ones(4, 100, dtype=torch.bool)),
+            self.dur2bd_path,
+            input_names=["durations", "maskT"],
+            output_names=["boundaries"],
+            dynamic_shapes=({0: "B", 1: "N"}, {0: "B", 1: "T"}),
+            dynamic_axes={
+                "durations": {0: "B", 1: "N"},
+                "maskT": {0: "B", 1: "T"},
+                "boundaries": {0: "B", 1: "T"},
+            },
         )
-        if self.dynamo:
-            _clear_stacktrace(program)
-            program.save(self.dur2bd_path)
-        _slim_onnx_model(self.dur2bd_path)
         logging.debug("Exporting dur2bd done.")
 
         logging.debug("Exporting bd2dur start.")
@@ -454,33 +270,15 @@ class Exporter:
                 torch.ones(4, 100, dtype=torch.bool),
             ),
             self.bd2dur_path,
-            input_names=[
-                "boundaries",
-                "maskT",
-            ],
-            output_names=[
-                "durations",
-                "maskN",
-            ],
-            dynamic_axes={
-                "boundaries": {
-                    0: "B",
-                    1: "T",
-                },
-                "maskT": {
-                    0: "B",
-                    1: "T",
-                },
-                "durations": {
-                    0: "B",
-                    1: "N",
-                },
-                "maskN": {
-                    0: "B",
-                    1: "N",
-                },
-            },
             # We don't use Dynamo here because the function contains dynamic shapes depending on inputs.
+            input_names=["boundaries", "maskT"],
+            output_names=["durations", "maskN"],
+            dynamic_axes={
+                "boundaries": {0: "B", 1: "T"},
+                "maskT": {0: "B", 1: "T"},
+                "durations": {0: "B", 1: "N"},
+                "maskN": {0: "B", 1: "N"},
+            },
             opset_version=min(20, self.opset_version),
             dynamo=False,
             external_data=False,

--- a/deployment/exporter.py
+++ b/deployment/exporter.py
@@ -281,6 +281,7 @@ class Exporter:
                 "durations": {0: "B", 1: "N"},
                 "maskN": {0: "B", 1: "N"},
             },
+            # We don't use Dynamo here because the function contains dynamic shapes depending on inputs.
             opset_version=min(20, self.opset_version),
             dynamo=False,
             external_data=False,

--- a/deployment/exporter.py
+++ b/deployment/exporter.py
@@ -108,8 +108,10 @@ class Exporter:
         self.dur2bd_path = self.save_dir / "dur2bd.onnx"
         self.bd2dur_path = self.save_dir / "bd2dur.onnx"
 
-    def _export(self, model, args, save_path, input_names, output_names,
-                 dynamic_axes=None, dynamic_shapes=None, kwargs=None):
+    def _export(
+        self, model, args, save_path, input_names, output_names,
+        dynamic_axes=None, dynamic_shapes=None, kwargs=None,
+    ):
         if self.dynamo:
             program = torch.onnx.export(
                 model, args, None,

--- a/inference/api.py
+++ b/inference/api.py
@@ -9,7 +9,7 @@ from torch import Tensor
 
 from lib import logging
 from lib.config.core import ConfigBaseModel
-from lib.config.formatter import ModelFormatter
+from lib.config.formatter import format_model
 from lib.config.io import load_raw_config
 from lib.config.schema import ModelConfig, InferenceConfig, ValidationConfig
 from .me_infer import SegmentationEstimationInferenceModel
@@ -26,8 +26,7 @@ __all__ = [
 
 @rank_zero_only
 def _log_config(cfg: ConfigBaseModel):
-    formatter = ModelFormatter()
-    print(formatter.format(cfg))
+    print(format_model(cfg))
 
 
 def load_config_for_inference(

--- a/inference/callbacks.py
+++ b/inference/callbacks.py
@@ -64,7 +64,7 @@ class _PartAggregatingCallback(lightning.pytorch.callbacks.Callback, abc.ABC):
             pl_module: lightning.pytorch.LightningModule,
             outputs: dict[str, torch.Tensor],
             batch: dict[str, Any],
-            *args, **kwargs
+            *args, **kwargs,
     ) -> None:
         for i in range(batch["size"]):
             key = self._get_key(batch, i)
@@ -77,7 +77,7 @@ class _PartAggregatingCallback(lightning.pytorch.callbacks.Callback, abc.ABC):
                 self._flush_key(key, logger_fn=trainer.progress_bar_callback.print)
 
     def on_predict_epoch_end(
-            self, trainer: lightning.pytorch.Trainer, *args, **kwargs
+            self, trainer: lightning.pytorch.Trainer, *args, **kwargs,
     ) -> None:
         for key in list(self._counters):
             self._flush_key(key, logger_fn=trainer.progress_bar_callback.print)
@@ -293,11 +293,13 @@ class UpdateDiffSingerTranscriptionsCallback(_PartAggregatingCallback):
         item = self.index_map[key][name]
         if self.use_wb:
             if self.uv_note_cond == "follow":
+                # When "follow", defer v/uv to align_notes_to_words; use raw pitch for all notes.
                 note_seq = [
                     librosa.midi_to_note(midi, unicode=False, cents=True)
                     for midi in note_midi
                 ]
             else:  # "predict"
+                # When "predict", apply presence-based "rest" now so alignment preserves them.
                 note_seq = [
                     librosa.midi_to_note(midi, unicode=False, cents=True) if vuv else "rest"
                     for midi, vuv in zip(note_midi, note_vuv)
@@ -322,6 +324,7 @@ class UpdateDiffSingerTranscriptionsCallback(_PartAggregatingCallback):
                 apply_word_uv=(self.uv_note_cond == "follow"),
             )
         else:
+            # No alignment: apply presence-based "rest" directly from model output.
             note_seq = [
                 librosa.midi_to_note(score, unicode=False, cents=True) if pres else "rest"
                 for score, pres in zip(note_midi, note_vuv)

--- a/inference/callbacks.py
+++ b/inference/callbacks.py
@@ -35,14 +35,28 @@ class _NoteInfo:
     pitch: float
 
 
-class SaveCombinedFileCallback(lightning.pytorch.callbacks.Callback, abc.ABC):
-    def __init__(self, output_dir: str | pathlib.Path):
+class _PartAggregatingCallback(lightning.pytorch.callbacks.Callback, abc.ABC):
+    """Base class for callbacks that aggregate partial results by key."""
+
+    def __init__(self):
         super().__init__()
-        if isinstance(output_dir, str):
-            output_dir = pathlib.Path(output_dir)
-        self.output_dir = output_dir
-        self.counters: dict[str, int] = {}
-        self.notes: dict[str, list[_NoteInfo]] = {}
+        self._counters: dict[str, int] = {}
+
+    @abc.abstractmethod
+    def _get_key(self, batch: dict, i: int) -> str:
+        """Extract the aggregation key for item i in the batch."""
+
+    @abc.abstractmethod
+    def _get_total(self, batch: dict, key: str, i: int) -> int:
+        """Return the expected total number of parts for the given key."""
+
+    @abc.abstractmethod
+    def _process_item(self, key: str, batch: dict, outputs: dict, i: int) -> None:
+        """Process item i for key, accumulating data into instance state."""
+
+    @abc.abstractmethod
+    def _flush_key(self, key: str, logger_fn: Callable) -> None:
+        """Flush accumulated data for key and clean up counters."""
 
     def on_predict_batch_end(
             self,
@@ -52,44 +66,67 @@ class SaveCombinedFileCallback(lightning.pytorch.callbacks.Callback, abc.ABC):
             batch: dict[str, Any],
             *args, **kwargs
     ) -> None:
-        batch_size = batch["size"]
-        for i in range(batch_size):
-            key: str = batch["key"][i]
-            num_parts = batch["num_parts"][i]
-            if key not in self.counters:
-                self.counters[key] = 0
-                self.notes[key] = []
-            offset: float = batch["offset"][i]
-            length: float = batch["length"][i]
-            durations = outputs["durations"][i]
-            scores = outputs["scores"][i]
-            presence = outputs["presence"][i]
-            note_onset = F.pad(
-                durations, (1, 0), mode="constant", value=0
-            ).cumsum(dim=0).clamp(max=length).add(offset)
-            note_offset = durations.cumsum(dim=0).clamp(max=length).add(offset)
-            for onset, offset, score, valid in zip(
-                    note_onset.tolist(),
-                    note_offset.tolist(),
-                    scores.tolist(),
-                    presence.tolist(),
-            ):
-                if offset - onset <= 0:
-                    continue
-                if not valid:
-                    continue
-                self.notes[key].append(_NoteInfo(
-                    onset=onset,
-                    offset=offset,
-                    pitch=score,
-                ))
-            self.counters[key] += 1
-            if self.counters[key] >= num_parts:
-                self.save_file(key, logger_fn=trainer.progress_bar_callback.print)
+        for i in range(batch["size"]):
+            key = self._get_key(batch, i)
+            total = self._get_total(batch, key, i)
+            if key not in self._counters:
+                self._counters[key] = 0
+            self._process_item(key, batch, outputs, i)
+            self._counters[key] += 1
+            if self._counters[key] >= total:
+                self._flush_key(key, logger_fn=trainer.progress_bar_callback.print)
 
-    def on_predict_epoch_end(self, trainer: lightning.pytorch.Trainer, *args, **kwargs) -> None:
-        for key in self.counters.keys():
-            self.save_file(key, logger_fn=trainer.progress_bar_callback.print)
+    def on_predict_epoch_end(
+            self, trainer: lightning.pytorch.Trainer, *args, **kwargs
+    ) -> None:
+        for key in list(self._counters):
+            self._flush_key(key, logger_fn=trainer.progress_bar_callback.print)
+
+
+class SaveCombinedFileCallback(_PartAggregatingCallback, abc.ABC):
+    def __init__(self, output_dir: str | pathlib.Path):
+        super().__init__()
+        if isinstance(output_dir, str):
+            output_dir = pathlib.Path(output_dir)
+        self.output_dir = output_dir
+        self.notes: dict[str, list[_NoteInfo]] = {}
+
+    def _get_key(self, batch: dict, i: int) -> str:
+        return batch["key"][i]
+
+    def _get_total(self, batch: dict, key: str, i: int) -> int:
+        return batch["num_parts"][i]
+
+    def _process_item(self, key: str, batch: dict, outputs: dict, i: int) -> None:
+        if key not in self.notes:
+            self.notes[key] = []
+        offset: float = batch["offset"][i]
+        length: float = batch["length"][i]
+        durations = outputs["durations"][i]
+        scores = outputs["scores"][i]
+        presence = outputs["presence"][i]
+        note_onset = F.pad(
+            durations, (1, 0), mode="constant", value=0
+        ).cumsum(dim=0).clamp(max=length).add(offset)
+        note_offset = durations.cumsum(dim=0).clamp(max=length).add(offset)
+        for onset, offset, score, valid in zip(
+                note_onset.tolist(),
+                note_offset.tolist(),
+                scores.tolist(),
+                presence.tolist(),
+        ):
+            if offset - onset <= 0:
+                continue
+            if not valid:
+                continue
+            self.notes[key].append(_NoteInfo(
+                onset=onset,
+                offset=offset,
+                pitch=score,
+            ))
+
+    def _flush_key(self, key: str, logger_fn: Callable) -> None:
+        self.save_file(key, logger_fn)
 
     def save_file(self, key: str, logger_fn: Callable) -> None:
         sorted_notes = sorted(self.notes[key], key=lambda x: (x.onset, x.offset, x.pitch))
@@ -105,7 +142,7 @@ class SaveCombinedFileCallback(lightning.pytorch.callbacks.Callback, abc.ABC):
                 last_time = note.offset
                 i += 1
         self.flush(key, sorted_notes, logger_fn)
-        del self.counters[key]
+        del self._counters[key]
         del self.notes[key]
 
     @abc.abstractmethod
@@ -199,7 +236,7 @@ class SaveCombinedTextFileCallback(SaveCombinedFileCallback):
             logging.info(f"Saved CSV file: {filepath.as_posix()}", callback=logger_fn)
 
 
-class UpdateDiffSingerTranscriptionsCallback(lightning.pytorch.callbacks.Callback):
+class UpdateDiffSingerTranscriptionsCallback(_PartAggregatingCallback):
     def __init__(
             self, filelist: list[pathlib.Path],
             overwrite: bool = False,
@@ -226,7 +263,6 @@ class UpdateDiffSingerTranscriptionsCallback(lightning.pytorch.callbacks.Callbac
         self.uv_note_cond = uv_note_cond
         self.index_map: dict[str, OrderedDict[str, dict[str, Any]]] = {}
         self.lengths: dict[str, int] = {}
-        self.counters: dict[str, int] = {}
         for index in filelist:
             with open(index, "r", encoding="utf8") as f:
                 items = list(csv.DictReader(f))
@@ -236,86 +272,71 @@ class UpdateDiffSingerTranscriptionsCallback(lightning.pytorch.callbacks.Callbac
                 key = index.as_posix()
                 self.index_map[key] = o_dict
                 self.lengths[key] = len(items)
-                self.counters[key] = 0
 
-    def on_predict_batch_end(
-            self,
-            trainer: lightning.pytorch.Trainer,
-            pl_module: lightning.pytorch.LightningModule,
-            outputs: dict[str, torch.Tensor],
-            batch: dict[str, Any],
-            *args, **kwargs
-    ) -> None:
-        batch_size = batch["size"]
-        for i in range(batch_size):
-            index: str = batch["index"][i]
-            name: str = batch["name"][i]
-            durations = outputs["durations"][i]
-            scores = outputs["scores"][i]
-            presence = outputs["presence"][i]
-            valid = durations > 0
+    def _get_key(self, batch: dict, i: int) -> str:
+        return batch["index"][i]
 
-            note_dur = durations[valid].tolist()
-            note_midi = scores[valid].tolist()
-            note_vuv = presence[valid].tolist()
+    def _get_total(self, batch: dict, key: str, i: int) -> int:
+        return self.lengths[key]
 
-            item = self.index_map[index][name]
-            if self.use_wb:
-                if self.uv_note_cond == "follow":
-                    # When "follow", defer v/uv to align_notes_to_words; use raw pitch for all notes.
-                    note_seq = [
-                        librosa.midi_to_note(midi, unicode=False, cents=True)
-                        for midi in note_midi
-                    ]
-                else:  # "predict"
-                    # When "predict", apply presence-based "rest" now so alignment preserves them.
-                    note_seq = [
-                        librosa.midi_to_note(midi, unicode=False, cents=True) if vuv else "rest"
-                        for midi, vuv in zip(note_midi, note_vuv)
-                    ]
-                ph_seq = item["ph_seq"].split()
-                ph_dur = [float(d) for d in item["ph_dur"].split()]
-                ph_num = [int(n) for n in item["ph_num"].split()]
-                is_valid, err_msg = validate_phones(ph_seq, ph_dur, ph_num)
-                if not is_valid:
-                    raise ValueError(
-                        f"Invalid phone sequence in item \'{name}\' in index \'{index}\': {err_msg}"
-                    )
-                word_dur, word_vuv = parse_words(
-                    ph_seq, ph_dur, ph_num,
-                    uv_vocab=self.uv_vocab,
-                    uv_cond=self.uv_word_cond,
-                    merge_consecutive_uv=False,
-                )
-                note_seq, note_dur, note_slur = align_notes_to_words(
-                    word_dur, word_vuv,
-                    note_seq, note_dur,
-                    apply_word_uv=(self.uv_note_cond == "follow"),
-                )
-            else:
-                # No alignment: apply presence-based "rest" directly from model output.
+    def _process_item(self, key: str, batch: dict, outputs: dict, i: int) -> None:
+        name: str = batch["name"][i]
+        durations = outputs["durations"][i]
+        scores = outputs["scores"][i]
+        presence = outputs["presence"][i]
+        valid = durations > 0
+
+        note_dur = durations[valid].tolist()
+        note_midi = scores[valid].tolist()
+        note_vuv = presence[valid].tolist()
+
+        item = self.index_map[key][name]
+        if self.use_wb:
+            if self.uv_note_cond == "follow":
                 note_seq = [
-                    librosa.midi_to_note(score, unicode=False, cents=True) if pres else "rest"
-                    for score, pres in zip(note_midi, note_vuv)
+                    librosa.midi_to_note(midi, unicode=False, cents=True)
+                    for midi in note_midi
                 ]
-                note_slur = None
+            else:  # "predict"
+                note_seq = [
+                    librosa.midi_to_note(midi, unicode=False, cents=True) if vuv else "rest"
+                    for midi, vuv in zip(note_midi, note_vuv)
+                ]
+            ph_seq = item["ph_seq"].split()
+            ph_dur = [float(d) for d in item["ph_dur"].split()]
+            ph_num = [int(n) for n in item["ph_num"].split()]
+            is_valid, err_msg = validate_phones(ph_seq, ph_dur, ph_num)
+            if not is_valid:
+                raise ValueError(
+                    f"Invalid phone sequence in item \'{name}\' in index \'{key}\': {err_msg}"
+                )
+            word_dur, word_vuv = parse_words(
+                ph_seq, ph_dur, ph_num,
+                uv_vocab=self.uv_vocab,
+                uv_cond=self.uv_word_cond,
+                merge_consecutive_uv=False,
+            )
+            note_seq, note_dur, note_slur = align_notes_to_words(
+                word_dur, word_vuv,
+                note_seq, note_dur,
+                apply_word_uv=(self.uv_note_cond == "follow"),
+            )
+        else:
+            note_seq = [
+                librosa.midi_to_note(score, unicode=False, cents=True) if pres else "rest"
+                for score, pres in zip(note_midi, note_vuv)
+            ]
+            note_slur = None
 
-            item["note_seq"] = " ".join(note_seq)
-            item["note_dur"] = " ".join(f"{dur:.3f}" for dur in note_dur)
-            if note_slur is None:
-                item.pop("note_slur", None)
-            else:
-                item["note_slur"] = " ".join(str(s) for s in note_slur)
-            item.pop("note_glide", None)
-            self.counters[index] += 1
-            if self.counters[index] >= self.lengths[index]:
-                self.flush(index, logger_fn=trainer.progress_bar_callback.print)
+        item["note_seq"] = " ".join(note_seq)
+        item["note_dur"] = " ".join(f"{dur:.3f}" for dur in note_dur)
+        if note_slur is None:
+            item.pop("note_slur", None)
+        else:
+            item["note_slur"] = " ".join(str(s) for s in note_slur)
+        item.pop("note_glide", None)
 
-    def on_predict_epoch_end(self, trainer: lightning.pytorch.Trainer, *args, **kwargs) -> None:
-        for index in self.counters.keys():
-            self.flush(index, logger_fn=trainer.progress_bar_callback.print)
-
-    def flush(self, key: str, logger_fn: Callable):
+    def _flush_key(self, key: str, logger_fn: Callable) -> None:
         items = list(self.index_map[key].values())
         index = pathlib.Path(key)
         if self.overwrite:
@@ -332,7 +353,7 @@ class UpdateDiffSingerTranscriptionsCallback(lightning.pytorch.callbacks.Callbac
             writer.writerows(items)
         del self.index_map[key]
         del self.lengths[key]
-        del self.counters[key]
+        del self._counters[key]
         logging.info(f"Saved transcriptions: {save_path.as_posix()}", callback=logger_fn)
 
 

--- a/inference/me_infer_module.py
+++ b/inference/me_infer_module.py
@@ -32,6 +32,11 @@ class InferenceModule(lightning.pytorch.LightningModule):
 
     def setup(self, stage: str) -> None:
         super().setup(stage)
+        if stage == "test" or stage == "predict":
+            self._d3pm_ts = torch.tensor(self.config.d3pm_sample_ts_resolved)
+            self._boundary_threshold = torch.tensor(self.config.boundary_decoding_threshold)
+            self._boundary_radius = torch.tensor(self.config.boundary_decoding_radius)
+            self._note_presence_threshold = torch.tensor(self.config.note_presence_threshold)
         if stage == "fit" or stage == "validate":
             raise ValueError(f"InferenceModule does not support stage '{stage}'.")
         if stage == "test":
@@ -67,10 +72,10 @@ class InferenceModule(lightning.pytorch.LightningModule):
             waveform=waveform,
             known_durations=known_durations,
             language=language,
-            t=torch.tensor(self.config.d3pm_sample_ts_resolved).to(waveform),
-            boundary_threshold=torch.tensor(self.config.boundary_decoding_threshold).to(waveform),
-            boundary_radius=torch.tensor(self.config.boundary_decoding_radius).to(language),
-            score_threshold=torch.tensor(self.config.note_presence_threshold).to(waveform),
+            t=self._d3pm_ts.to(waveform),
+            boundary_threshold=self._boundary_threshold.to(waveform),
+            boundary_radius=self._boundary_radius.to(language),
+            score_threshold=self._note_presence_threshold.to(waveform),
         )
         return {
             "durations": durations,
@@ -94,15 +99,15 @@ class InferenceModule(lightning.pytorch.LightningModule):
         boundaries_pred, regions_pred, max_n_pred = self.model.forward_segmenter_main(
             x_seg, known_boundaries=torch.zeros_like(boundaries), mask=mask,
             language=language_ids,
-            t=torch.tensor(self.config.d3pm_sample_ts_resolved).to(spectrogram),
-            threshold=torch.tensor(self.config.boundary_decoding_threshold).to(spectrogram),
-            radius=torch.tensor(self.config.boundary_decoding_radius).to(regions),
+            t=self._d3pm_ts.to(spectrogram),
+            threshold=self._boundary_threshold.to(spectrogram),
+            radius=self._boundary_radius.to(regions),
         )
         durations_frame_pred = regions_to_durations(regions_pred, max_n=max_n_pred)  # [B, N]
         durations_pred = durations_frame_pred * self.timestep
         presence_pred, scores_pred = self.model.forward_estimator(
             x_est, regions=regions_pred, mask=mask, max_n=max_n_pred,
-            threshold=torch.tensor(self.config.note_presence_threshold).to(spectrogram),
+            threshold=self._note_presence_threshold.to(spectrogram),
         )
 
         self._update_metrics(

--- a/inference/slicer2.py
+++ b/inference/slicer2.py
@@ -39,13 +39,15 @@ def get_rms(
 
 
 class Slicer:
-    def __init__(self,
-                 sr: int,
-                 threshold: float = -40.,
-                 min_length: int = 5000,
-                 min_interval: int = 300,
-                 hop_size: int = 20,
-                 max_sil_kept: int = 5000):
+    def __init__(
+            self,
+            sr: int,
+            threshold: float = -40.,
+            min_length: int = 5000,
+            min_interval: int = 300,
+            hop_size: int = 20,
+            max_sil_kept: int = 5000,
+    ):
         if not min_length >= min_interval >= hop_size:
             raise ValueError('The following condition must be satisfied: min_length >= min_interval >= hop_size')
         if not max_sil_kept >= hop_size:

--- a/lib/config/core.py
+++ b/lib/config/core.py
@@ -11,6 +11,7 @@ __all__ = [
 
 # Context variable holds current scope
 _current_scope: ContextVar[int] = ContextVar("_current_scope")
+_SCOPE_UNSET = object()
 
 
 class ConfigBaseModel(BaseModel):
@@ -27,9 +28,8 @@ class ConfigBaseModel(BaseModel):
     __field_scopes__: ClassVar[dict] = {}  # {field_name: scope_bitmask}
 
     def __init__(self, **data):
-        try:
-            _current_scope.get()
-        except LookupError:
+        scope = _current_scope.get(_SCOPE_UNSET)
+        if scope is _SCOPE_UNSET:
             token = _current_scope.set(0)
             try:
                 super().__init__(**data)

--- a/lib/config/core.py
+++ b/lib/config/core.py
@@ -73,8 +73,10 @@ class ConfigBaseModel(BaseModel):
                     delattr(self, name)
         return self
 
-    def _walk_config_fields(self, current: "ConfigBaseModel", context: ConfigOperationContext,
-                            leaf_fn):
+    def _walk_config_fields(
+            self, current: "ConfigBaseModel", context: ConfigOperationContext,
+            leaf_fn,
+    ):
         for field_name, field_info in type(current).model_fields.items():
             field_scope = current.__field_scopes__.get(field_name)
             if field_scope is not None and not field_scope & context.scope:
@@ -94,6 +96,8 @@ class ConfigBaseModel(BaseModel):
             context.current_path.pop()
 
     def _resolve_recursive(self, current: "ConfigBaseModel", context: ConfigOperationContext):
+        """Recursively resolve all dynamic expressions in the config."""
+
         def _resolve_leaf(current, field_name, field_info, value, context):
             expr = field_info.json_schema_extra.get('dynamic_expr')
             if expr:
@@ -101,14 +105,18 @@ class ConfigBaseModel(BaseModel):
                     context.current_value = value
                     expr = expr.resolve(context)
                 setattr(current, field_name, expr)
+
         self._walk_config_fields(current, context, _resolve_leaf)
 
     def _check_recursive(self, current: "ConfigBaseModel", context: ConfigOperationContext):
+        """Recursively check all dynamic expressions in the config."""
+
         def _check_leaf(current, field_name, field_info, value, context):
             check = field_info.json_schema_extra.get('dynamic_check')
             if check:
                 context.current_value = value
                 check.run(context)
+
         self._walk_config_fields(current, context, _check_leaf)
 
     def _process_nested(self, f, scope: int = 0, path: str = None):

--- a/lib/config/core.py
+++ b/lib/config/core.py
@@ -73,12 +73,8 @@ class ConfigBaseModel(BaseModel):
                     delattr(self, name)
         return self
 
-    def _resolve_recursive(self, current: "ConfigBaseModel", context: ConfigOperationContext):
-        """
-        Recursively resolve all dynamic expressions in the config.
-        :param current: The current model instance.
-        :param context: The context for resolving dynamic expressions.
-        """
+    def _walk_config_fields(self, current: "ConfigBaseModel", context: ConfigOperationContext,
+                            leaf_fn):
         for field_name, field_info in type(current).model_fields.items():
             field_scope = current.__field_scopes__.get(field_name)
             if field_scope is not None and not field_scope & context.scope:
@@ -86,48 +82,34 @@ class ConfigBaseModel(BaseModel):
             context.current_path.append(field_name)
             value = getattr(current, field_name)
             if isinstance(value, ConfigBaseModel):
-                self._resolve_recursive(value, context)
+                self._walk_config_fields(value, context, leaf_fn)
             elif isinstance(value, list):
                 for i, item in enumerate(value):
                     context.current_path.append(i)
                     if isinstance(item, ConfigBaseModel):
-                        self._resolve_recursive(item, context)
+                        self._walk_config_fields(item, context, leaf_fn)
                     context.current_path.pop()
             if field_info.json_schema_extra is not None:
-                expr = field_info.json_schema_extra.get('dynamic_expr')
-                if expr:
-                    if isinstance(expr, ConfigOperationBase):
-                        context.current_value = value
-                        expr = expr.resolve(context)
-                    setattr(current, field_name, expr)
+                leaf_fn(current, field_name, field_info, value, context)
             context.current_path.pop()
 
-    def _check_recursive(self, current: "ConfigBaseModel", context: ConfigOperationContext):
-        """
-        Recursively check all dynamic expressions in the config.
-        :param current: The current model instance.
-        :param context: The context for checking dynamic expressions.
-        """
-        for field_name, field_info in type(current).model_fields.items():
-            field_scope = current.__field_scopes__.get(field_name)
-            if field_scope is not None and not field_scope & context.scope:
-                continue
-            context.current_path.append(field_name)
-            value = getattr(current, field_name)
-            if isinstance(value, ConfigBaseModel):
-                self._check_recursive(value, context)
-            elif isinstance(value, list):
-                for i, item in enumerate(value):
-                    context.current_path.append(i)
-                    if isinstance(item, ConfigBaseModel):
-                        self._check_recursive(item, context)
-                    context.current_path.pop()
-            if field_info.json_schema_extra is not None:
-                check = field_info.json_schema_extra.get('dynamic_check')
-                if check:
+    def _resolve_recursive(self, current: "ConfigBaseModel", context: ConfigOperationContext):
+        def _resolve_leaf(current, field_name, field_info, value, context):
+            expr = field_info.json_schema_extra.get('dynamic_expr')
+            if expr:
+                if isinstance(expr, ConfigOperationBase):
                     context.current_value = value
-                    check.run(context)
-            context.current_path.pop()
+                    expr = expr.resolve(context)
+                setattr(current, field_name, expr)
+        self._walk_config_fields(current, context, _resolve_leaf)
+
+    def _check_recursive(self, current: "ConfigBaseModel", context: ConfigOperationContext):
+        def _check_leaf(current, field_name, field_info, value, context):
+            check = field_info.json_schema_extra.get('dynamic_check')
+            if check:
+                context.current_value = value
+                check.run(context)
+        self._walk_config_fields(current, context, _check_leaf)
 
     def _process_nested(self, f, scope: int = 0, path: str = None):
         """

--- a/lib/config/formatter.py
+++ b/lib/config/formatter.py
@@ -73,14 +73,20 @@ def _get_width(fmt: _Fmt, key: Optional[str], value: Any) -> int:
     return width
 
 
+def _entries_width(fmt: _Fmt, entries: list) -> int:
+    items_width = sum(_get_width(fmt, k, v) for k, v in entries)
+    separators_width = (len(entries) - 1) * len(fmt.separator)
+    return items_width + separators_width + 2  # brackets
+
+
 def _process(fmt: _Fmt, elements: list, prefix: str, suffix: str):
     fmt.cur_line.append(prefix)
     fmt.cur_width += len(_strip_ansi(prefix))
-    if _get_width(fmt, None, elements) > fmt.max_width():
+    if _entries_width(fmt, elements) > fmt.max_width():
         fmt.flush_line()
         fmt.level += 1
     _add_entries(fmt, elements)
-    if _get_width(fmt, None, elements) > fmt.max_width():
+    if _entries_width(fmt, elements) > fmt.max_width():
         fmt.flush_line()
         fmt.level -= 1
     fmt.cur_line.append(suffix)

--- a/lib/config/formatter.py
+++ b/lib/config/formatter.py
@@ -133,8 +133,10 @@ def _add_entry(fmt: _Fmt, key: Optional[str], value: Any):
         fmt.cur_width += width
 
 
-def format_model(model: BaseModel, line_width: int = 80, indent: int = 4,
-                 connector: str = ": ", separator: str = ", ") -> str:
+def format_model(
+    model: BaseModel, line_width: int = 80, indent: int = 4,
+    connector: str = ": ", separator: str = ", ",
+) -> str:
     """Format a Pydantic model as a readable string."""
     fmt = _Fmt(line_width=line_width, indent=indent, connector=connector, separator=separator)
     _add_entry(fmt, None, model)

--- a/lib/config/formatter.py
+++ b/lib/config/formatter.py
@@ -1,10 +1,11 @@
 import re
-from typing import Any, List, Optional, Tuple
+from dataclasses import dataclass, field
+from typing import Any, Optional
 
 from pydantic import BaseModel
 
 __all__ = [
-    "ModelFormatter",
+    "format_model",
 ]
 
 _ANSI_RE = re.compile(r'\033\[[0-9;]*m')
@@ -14,130 +15,128 @@ def _strip_ansi(s: str) -> str:
     return _ANSI_RE.sub('', s)
 
 
-class ModelFormatter:
-    def __init__(self, line_width: int = 80, indent: int = 4, connector: str = ": ", separator: str = ", "):
-        self.line_width = line_width
-        self.indent = indent
-        self.connector = connector
-        self.separator = separator
-        self.lines = []
-        self.current_level = 0
-        self.current_line = []
-        self.current_width = 0
-        self.width_cache = {}
+@dataclass
+class _Fmt:
+    line_width: int
+    indent: int
+    connector: str
+    separator: str
+    lines: list[str] = field(default_factory=list)
+    level: int = 0
+    cur_line: list[str] = field(default_factory=list)
+    cur_width: int = 0
+    width_cache: dict = field(default_factory=dict)
 
-    def reset(self):
-        self.lines = []
-        self.current_level = 0
-        self.current_line = []
-        self.current_width = 0
-        self.width_cache.clear()
+    def max_width(self) -> int:
+        return self.line_width - self.level * self.indent
 
-    def current_max_width(self):
-        return self.line_width - self.current_level * self.indent
+    def remaining_width(self) -> int:
+        return self.max_width() - self.cur_width
 
-    def current_remaining_width(self):
-        return self.current_max_width() - self.current_width
+    def flush_line(self):
+        if self.cur_line:
+            self.lines.append(" " * (self.level * self.indent) + "".join(self.cur_line))
+            self.cur_line = []
+            self.cur_width = 0
 
-    def get_width(self, key: Optional[str], value: Any) -> int:
-        cache_key = (key, id(value))
-        if cache_key in self.width_cache:
-            return self.width_cache[cache_key]
 
-        key_width = 0 if key is None else len(key) + len(self.connector)
-        if isinstance(value, BaseModel):
-            if any(
-                not field.exclude and hasattr(value, name) and getattr(value, name) is not None
+def _get_width(fmt: _Fmt, key: Optional[str], value: Any) -> int:
+    cache_key = (key, id(value))
+    if cache_key in fmt.width_cache:
+        return fmt.width_cache[cache_key]
+
+    key_width = 0 if key is None else len(key) + len(fmt.connector)
+    if isinstance(value, BaseModel):
+        if any(
+            not field.exclude and hasattr(value, name) and getattr(value, name) is not None
+            for name, field in type(value).model_fields.items()
+        ):
+            width = float('inf')
+        else:
+            width = key_width + 2
+    elif isinstance(value, (tuple, list)):
+        item_count = len(value)
+        items_width = sum(_get_width(fmt, None, item) for item in value)
+        separators_width = (item_count - 1) * len(fmt.separator)
+        brackets_width = 2
+        width = items_width + key_width + separators_width + brackets_width
+    elif isinstance(value, dict):
+        item_count = len(value)
+        items_width = sum(_get_width(fmt, k, v) for k, v in value.items())
+        separators_width = (item_count - 1) * len(fmt.separator)
+        braces_width = 2
+        width = items_width + key_width + separators_width + braces_width
+    else:
+        width = len(str(value)) + key_width
+
+    fmt.width_cache[cache_key] = width
+    return width
+
+
+def _process(fmt: _Fmt, elements: list, prefix: str, suffix: str):
+    fmt.cur_line.append(prefix)
+    fmt.cur_width += len(_strip_ansi(prefix))
+    if _get_width(fmt, None, elements) > fmt.max_width():
+        fmt.flush_line()
+        fmt.level += 1
+    _add_entries(fmt, elements)
+    if _get_width(fmt, None, elements) > fmt.max_width():
+        fmt.flush_line()
+        fmt.level -= 1
+    fmt.cur_line.append(suffix)
+    fmt.cur_width += len(_strip_ansi(suffix))
+
+
+def _add_entries(fmt: _Fmt, entries: list):
+    for idx, (key, value) in enumerate(entries):
+        width = _get_width(fmt, key, value)
+        if width > fmt.remaining_width():
+            fmt.flush_line()
+            _add_entry(fmt, key, value)
+            if idx < len(entries) - 1:
+                fmt.cur_line.append(fmt.separator)
+                fmt.cur_width += len(fmt.separator)
+            if width > fmt.max_width():
+                fmt.flush_line()
+        else:
+            _add_entry(fmt, key, value)
+            if idx < len(entries) - 1:
+                fmt.cur_line.append(fmt.separator)
+                fmt.cur_width += len(fmt.separator)
+
+
+def _add_entry(fmt: _Fmt, key: Optional[str], value: Any):
+    width = _get_width(fmt, key, value)
+    if width > fmt.remaining_width():
+        fmt.flush_line()
+    prefix = "" if key is None else f"\033[0;33m{key}\033[0m{fmt.connector}"
+
+    if isinstance(value, tuple):
+        _process(fmt, [(None, item) for item in value], prefix + "(", ")")
+    elif isinstance(value, list):
+        _process(fmt, [(None, item) for item in value], prefix + "[", "]")
+    elif isinstance(value, dict):
+        _process(fmt, list(value.items()), prefix + "{", "}")
+    elif isinstance(value, BaseModel):
+        _process(
+            fmt,
+            [
+                (name, getattr(value, name))
                 for name, field in type(value).model_fields.items()
-            ):
-                width = float('inf')  # force new line
-            else:
-                width = key_width + 2  # wrap empty object
-        elif isinstance(value, (tuple, list)):
-            item_count = len(value)
-            items_width = sum(self.get_width(None, item) for item in value)
-            separators_width = (item_count - 1) * len(self.separator)
-            brackets_width = 2
-            width = items_width + key_width + separators_width + brackets_width
-        elif isinstance(value, dict):
-            item_count = len(value)
-            items_width = sum(self.get_width(k, v) for k, v in value.items())
-            separators_width = (item_count - 1) * len(self.separator)
-            braces_width = 2
-            width = items_width + key_width + separators_width + braces_width
-        else:
-            width = len(str(value)) + key_width
+                if hasattr(value, name) and not field.exclude
+            ],
+            prefix + f"{value.__class__.__name__}(",
+            ")",
+        )
+    else:
+        fmt.cur_line.append(f"{prefix}{value}")
+        fmt.cur_width += width
 
-        self.width_cache[cache_key] = width
-        return width
 
-    def new_line(self):
-        if self.current_line:
-            self.lines.append(" " * (self.current_level * self.indent) + "".join(self.current_line))
-            self.current_line = []
-            self.current_width = 0
-
-    def add_entries(self, entries: List[Tuple[Optional[str], Any]]):
-        for idx, (key, value) in enumerate(entries):
-            width = self.get_width(key, value)
-            if width > self.current_remaining_width():
-                self.new_line()
-                self.add_entry(key, value)
-                if idx < len(entries) - 1:
-                    self.current_line.append(self.separator)
-                    self.current_width += len(self.separator)
-                if width > self.current_max_width():
-                    self.new_line()
-            else:
-                self.add_entry(key, value)
-                if idx < len(entries) - 1:
-                    self.current_line.append(self.separator)
-                    self.current_width += len(self.separator)
-
-    def add_entry(self, key: Optional[str], value: Any):
-        width = self.get_width(key, value)
-        if width > self.current_remaining_width():
-            self.new_line()
-        if key is None:
-            prefix = ""
-        else:
-            prefix = f"\033[0;33m{key}\033[0m{self.connector}"
-
-        def _process(_elements: List[Tuple[Optional[str], Any]], _prefix: str, _suffix: str):
-            self.current_line.append(_prefix)
-            self.current_width += len(_strip_ansi(_prefix))
-            if width > self.current_max_width():
-                self.new_line()
-                self.current_level += 1
-            self.add_entries(_elements)
-            if width > self.current_max_width():
-                self.new_line()
-                self.current_level -= 1
-            self.current_line.append(_suffix)
-            self.current_width += len(_strip_ansi(_suffix))
-
-        if isinstance(value, tuple):
-            _process([(None, item) for item in value], prefix + "(", ")")
-        elif isinstance(value, list):
-            _process([(None, item) for item in value], prefix + "[", "]")
-        elif isinstance(value, dict):
-            _process(value.items(), prefix + "{", "}")
-        elif isinstance(value, BaseModel):
-            _process(
-                [
-                    (name, getattr(value, name))
-                    for name, field in type(value).model_fields.items()
-                    if hasattr(value, name) and not field.exclude
-                ],
-                prefix + f"{value.__class__.__name__}(", ")",
-            )
-        else:
-            self.current_line.append(f"{prefix}{value}")
-            self.current_width += width
-
-    def format(self, model: BaseModel) -> str:
-        self.add_entry(None, model)
-        self.new_line()
-        result = "\n".join(ln.rstrip() for ln in self.lines)
-        self.reset()
-        return result
+def format_model(model: BaseModel, line_width: int = 80, indent: int = 4,
+                 connector: str = ": ", separator: str = ", ") -> str:
+    """Format a Pydantic model as a readable string."""
+    fmt = _Fmt(line_width=line_width, indent=indent, connector=connector, separator=separator)
+    _add_entry(fmt, None, model)
+    fmt.flush_line()
+    return "\n".join(ln.rstrip() for ln in fmt.lines)

--- a/lib/config/formatter.py
+++ b/lib/config/formatter.py
@@ -51,9 +51,9 @@ def _get_width(fmt: _Fmt, key: Optional[str], value: Any) -> int:
             not field.exclude and hasattr(value, name) and getattr(value, name) is not None
             for name, field in type(value).model_fields.items()
         ):
-            width = float('inf')
+            width = float('inf')  # force new line
         else:
-            width = key_width + 2
+            width = key_width + 2  # wrap empty object
     elif isinstance(value, (tuple, list)):
         item_count = len(value)
         items_width = sum(_get_width(fmt, None, item) for item in value)

--- a/lib/config/ops.py
+++ b/lib/config/ops.py
@@ -153,6 +153,53 @@ class GetContext(ConfigOperationBase):
         return getattr(context, self.attr, None)
 
 
+import operator as _operator
+
+_BINARY_OPS = {
+    "+": _operator.add,
+    "-": _operator.sub,
+    "*": _operator.mul,
+    "/": _operator.truediv,
+    "%": _operator.mod,
+    "**": _operator.pow,
+    "//": _operator.floordiv,
+    "==": _operator.eq,
+    "!=": _operator.ne,
+    "<": _operator.lt,
+    "<=": _operator.le,
+    ">": _operator.gt,
+    ">=": _operator.ge,
+    "&": _operator.and_,
+    "|": _operator.or_,
+    "^": _operator.xor,
+    "and": lambda a, b: a and b,
+    "or": lambda a, b: a or b,
+    "in": lambda a, b: a in b,
+}
+
+_UNARY_OPS = {
+    "-": _operator.neg,
+    "~": _operator.invert,
+    "abs": abs,
+    "round": round,
+    "not": _operator.not_,
+    "exists": lambda x: x is not None,
+    "missing": lambda x: x is None,
+}
+
+_AGGREGATION_OPS = {
+    "min": lambda values: min(*values),
+    "max": lambda values: max(*values),
+    "len": lambda values: len(*values),
+    "sum": lambda values: sum(*values),
+    "avg": lambda values: sum(*values) / len(*values),
+    "all": lambda values: all(*values),
+    "any": lambda values: any(*values),
+    "list": lambda values: list(*values),
+    "set": lambda values: set(*values),
+}
+
+
 class BinaryOperation(ConfigOperationBase):
     def __init__(self, left, right, op):
         self.left = left
@@ -160,54 +207,11 @@ class BinaryOperation(ConfigOperationBase):
         self.op = op
 
     def resolve(self, context: ConfigOperationContext):
-        if isinstance(self.left, ConfigOperationBase):
-            left_value = self.left.resolve(context)
-        else:
-            left_value = self.left
-        if isinstance(self.right, ConfigOperationBase):
-            right_value = self.right.resolve(context)
-        else:
-            right_value = self.right
-        if self.op == "+":
-            return left_value + right_value
-        elif self.op == "-":
-            return left_value - right_value
-        elif self.op == "*":
-            return left_value * right_value
-        elif self.op == "/":
-            return left_value / right_value
-        elif self.op == "%":
-            return left_value % right_value
-        elif self.op == "**":
-            return left_value ** right_value
-        elif self.op == "//":
-            return left_value // right_value
-        elif self.op == "==":
-            return left_value == right_value
-        elif self.op == "!=":
-            return left_value != right_value
-        elif self.op == "<":
-            return left_value < right_value
-        elif self.op == "<=":
-            return left_value <= right_value
-        elif self.op == ">":
-            return left_value > right_value
-        elif self.op == ">=":
-            return left_value >= right_value
-        elif self.op == '&':
-            return left_value & right_value
-        elif self.op == '|':
-            return left_value | right_value
-        elif self.op == '^':
-            return left_value ^ right_value
-        elif self.op == 'and':
-            return left_value and right_value
-        elif self.op == 'or':
-            return left_value or right_value
-        elif self.op == 'in':
-            return left_value in right_value
-        else:
+        left_value = self.left.resolve(context) if isinstance(self.left, ConfigOperationBase) else self.left
+        right_value = self.right.resolve(context) if isinstance(self.right, ConfigOperationBase) else self.right
+        if self.op not in _BINARY_OPS:
             raise ValueError(f"Unsupported operator: {self.op}")
+        return _BINARY_OPS[self.op](left_value, right_value)
 
 
 class UnaryOperation(ConfigOperationBase):
@@ -216,26 +220,12 @@ class UnaryOperation(ConfigOperationBase):
         self.op = op
 
     def resolve(self, context: ConfigOperationContext):
-        if isinstance(self.operand, ConfigOperationBase):
-            operand_value = self.operand.resolve(context)
-        else:
-            operand_value = self.operand
-        if self.op == "-":
-            return -operand_value
-        elif self.op == "~":
-            return ~operand_value
-        elif self.op == "abs":
-            return abs(operand_value)
-        elif self.op == "round":
-            return round(operand_value)
-        elif self.op == 'not':
-            return not operand_value
-        elif self.op == 'exists':
-            return operand_value is not None
-        elif self.op == 'missing':
-            return operand_value is None
-        else:
+        operand_value = (
+            self.operand.resolve(context) if isinstance(self.operand, ConfigOperationBase) else self.operand
+        )
+        if self.op not in _UNARY_OPS:
             raise ValueError(f"Unsupported operator: {self.op}")
+        return _UNARY_OPS[self.op](operand_value)
 
 
 class Aggregation(ConfigOperationBase):
@@ -245,11 +235,11 @@ class Aggregation(ConfigOperationBase):
         self.key = key
 
     def resolve(self, context: ConfigOperationContext):
-        values = []
         if isinstance(self.args, ConfigOperationBase):
             args = self.args.resolve(context)
         else:
             args = self.args
+        values = []
         for arg in args:
             if isinstance(arg, ConfigOperationBase):
                 value = arg.resolve(context)
@@ -258,26 +248,9 @@ class Aggregation(ConfigOperationBase):
             if self.key:
                 value = self.key(value)
             values.append(value)
-        if self.op == "min":
-            return min(*values)
-        elif self.op == "max":
-            return max(*values)
-        elif self.op == "len":
-            return len(*values)
-        elif self.op == "sum":
-            return sum(*values)
-        elif self.op == "avg":
-            return sum(*values) / len(*values)
-        elif self.op == "all":
-            return all(*values)
-        elif self.op == "any":
-            return any(*values)
-        elif self.op == "list":
-            return list(*values)
-        elif self.op == "set":
-            return set(*values)
-        else:
+        if self.op not in _AGGREGATION_OPS:
             raise ValueError(f"Unsupported aggregation operation: {self.op}")
+        return _AGGREGATION_OPS[self.op](values)
 
 
 class Coalesce(ConfigOperationBase):

--- a/lib/config/ops.py
+++ b/lib/config/ops.py
@@ -1,4 +1,5 @@
 import abc
+import operator as _operator
 import re
 
 from pydantic import BaseModel
@@ -152,8 +153,6 @@ class GetContext(ConfigOperationBase):
             return context
         return getattr(context, self.attr, None)
 
-
-import operator as _operator
 
 _BINARY_OPS = {
     "+": _operator.add,

--- a/lib/config/schema.py
+++ b/lib/config/schema.py
@@ -236,6 +236,20 @@ class OptimizerConfig(ConfigBaseModel):
     kwargs: dict[str, Any] = Field(...)
 
 
+def _walk_lr_scheduler_configs(obj, fn):
+    """Recursively apply *fn* to every LRSchedulerConfig-shaped entry in *obj*."""
+    if isinstance(obj, LRSchedulerConfig):
+        return fn(obj)
+    if isinstance(obj, dict):
+        if "cls" in obj:
+            obj.setdefault("kwargs", {})
+            return fn(LRSchedulerConfig.model_validate(obj))
+        return {k: _walk_lr_scheduler_configs(v, fn) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_walk_lr_scheduler_configs(item, fn) for item in obj]
+    return obj
+
+
 class LRSchedulerConfig(ConfigBaseModel):
     cls: str = Field(...)
     kwargs: dict[str, Any] = Field(...)
@@ -245,21 +259,7 @@ class LRSchedulerConfig(ConfigBaseModel):
     # noinspection PyMethodParameters
     @field_validator("kwargs")
     def check_kwargs(cls, v):
-        res = {}
-        for key, value in v.items():
-            if isinstance(value, dict):
-                if "cls" in value:
-                    value.setdefault("kwargs", {})
-                    value = LRSchedulerConfig.model_validate(value)
-                else:
-                    value = LRSchedulerConfig.check_kwargs(value)
-            elif isinstance(value, list):
-                value = [
-                    LRSchedulerConfig.model_validate(item) if isinstance(item, dict) and "cls" in item else item
-                    for item in value
-                ]
-            res[key] = value
-        return res
+        return _walk_lr_scheduler_configs(v, lambda x: x)
 
 
 class PeriodicCheckpointConfig(ConfigBaseModel):

--- a/lib/config/schema.py
+++ b/lib/config/schema.py
@@ -155,11 +155,11 @@ class NaturalNoiseAugmentationConfig(ConfigBaseModel):
     prob: float = Field(0.25, gt=0.0, le=1.0)
     max_repeats: int = Field(1, ge=1)
     noise_path_glob: str = Field("data/noise/**/*.wav")
-    _noise_file_list: list[str] = PrivateAttr(default_factory=list)
+    _noise_file_list: list[str] | None = PrivateAttr(default=None)
 
     @property
     def noise_file_list(self) -> list[str]:
-        if not self._noise_file_list:
+        if self._noise_file_list is None:
             self._noise_file_list = glob.glob(self.noise_path_glob, recursive=True)
         return self._noise_file_list
 
@@ -168,11 +168,11 @@ class RIRReverbAugmentationConfig(ConfigBaseModel):
     enabled: bool = Field(False)
     prob: float = Field(0.25, gt=0.0, le=1.0)
     kernel_path_glob: str = Field("data/reverb/**/*.wav")
-    _kernel_file_list: list[str] = PrivateAttr(default_factory=list)
+    _kernel_file_list: list[str] | None = PrivateAttr(default=None)
 
     @property
     def kernel_file_list(self) -> list[str]:
-        if not self._kernel_file_list:
+        if self._kernel_file_list is None:
             self._kernel_file_list = glob.glob(self.kernel_path_glob, recursive=True)
         return self._kernel_file_list
 

--- a/lib/config/schema.py
+++ b/lib/config/schema.py
@@ -2,7 +2,7 @@ import glob
 import pathlib
 from typing import Annotated, Any, Literal, Union
 
-from pydantic import Field, field_validator
+from pydantic import Field, PrivateAttr, field_validator
 
 from .core import ConfigBaseModel
 from .ops import (
@@ -155,11 +155,11 @@ class NaturalNoiseAugmentationConfig(ConfigBaseModel):
     prob: float = Field(0.25, gt=0.0, le=1.0)
     max_repeats: int = Field(1, ge=1)
     noise_path_glob: str = Field("data/noise/**/*.wav")
+    _noise_file_list: list[str] = PrivateAttr(default_factory=list)
 
     @property
     def noise_file_list(self) -> list[str]:
-        if not hasattr(self, "_noise_file_list"):
-            # noinspection PyAttributeOutsideInit
+        if not self._noise_file_list:
             self._noise_file_list = glob.glob(self.noise_path_glob, recursive=True)
         return self._noise_file_list
 
@@ -168,11 +168,11 @@ class RIRReverbAugmentationConfig(ConfigBaseModel):
     enabled: bool = Field(False)
     prob: float = Field(0.25, gt=0.0, le=1.0)
     kernel_path_glob: str = Field("data/reverb/**/*.wav")
+    _kernel_file_list: list[str] = PrivateAttr(default_factory=list)
 
     @property
     def kernel_file_list(self) -> list[str]:
-        if not hasattr(self, "_kernel_file_list"):
-            # noinspection PyAttributeOutsideInit
+        if not self._kernel_file_list:
             self._kernel_file_list = glob.glob(self.kernel_path_glob, recursive=True)
         return self._kernel_file_list
 

--- a/lib/indexed_dataset.py
+++ b/lib/indexed_dataset.py
@@ -11,22 +11,28 @@ class IndexedDataset:
         self.path = pathlib.Path(path) / f"{prefix}.data.hdf5"
         if not self.path.exists():
             raise FileNotFoundError(f"IndexedDataset not found: {self.path}")
-        self.dset = None
+        self._dset = None
         self.cache = deque(maxlen=num_cache)
         self.num_cache = num_cache
 
-    def check_index(self, i):
-        if i < 0 or i >= len(self.dset):
-            raise IndexError("index out of range")
+    @property
+    def dset(self):
+        if self._dset is None:
+            self._dset = h5py.File(self.path, "r")
+        return self._dset
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["_dset"] = None
+        return state
 
     def __del__(self):
-        if self.dset:
-            self.dset.close()
+        if self._dset:
+            self._dset.close()
 
     def __getitem__(self, i):
-        if self.dset is None:
-            self.dset = h5py.File(self.path, "r")
-        self.check_index(i)
+        if i < 0 or i >= len(self.dset):
+            raise IndexError("index out of range")
         if self.num_cache > 0:
             for c in self.cache:
                 if c[0] == i:
@@ -34,7 +40,7 @@ class IndexedDataset:
         item = {}
         for k, v in self.dset[str(i)].items():
             v = v[()]
-            if v.ndim == 0:  # scalars saved as numpy.ndarray but loaded with numpy scalar types
+            if v.ndim == 0:
                 v = torch.tensor(v)
             else:
                 v = torch.from_numpy(v)
@@ -44,8 +50,6 @@ class IndexedDataset:
         return item
 
     def __len__(self):
-        if self.dset is None:
-            self.dset = h5py.File(self.path, "r")
         return len(self.dset)
 
 

--- a/lib/indexed_dataset.py
+++ b/lib/indexed_dataset.py
@@ -40,7 +40,7 @@ class IndexedDataset:
         item = {}
         for k, v in self.dset[str(i)].items():
             v = v[()]
-            if v.ndim == 0:
+            if v.ndim == 0:  # scalars saved as numpy.ndarray but loaded with numpy scalar types
                 v = torch.tensor(v)
             else:
                 v = torch.from_numpy(v)

--- a/lib/logging.py
+++ b/lib/logging.py
@@ -38,6 +38,7 @@ def _get_bind(last=1):
     """Walk the stack to get the real caller's module, function, and line."""
     frame = inspect.currentframe()
     try:
+        # Get the caller's frame
         for _ in range(last + 1):
             frame = frame.f_back
         name = frame.f_globals["__name__"]

--- a/lib/logging.py
+++ b/lib/logging.py
@@ -1,5 +1,5 @@
+import contextvars
 import inspect
-import io
 import sys
 
 from loguru import logger
@@ -12,16 +12,32 @@ _PRIVATE_LOGGER_FORMAT = (
     "{time:YYYY-MM-DD HH:mm:ss.SSS} | <level>{level:<8}</level> | "
     "<cyan>{extra[name]}</cyan>:<cyan>{extra[function]}</cyan>:<cyan>{extra[line]}</cyan> - <level>{message}</level>"
 )
+_log_callback: contextvars.ContextVar = contextvars.ContextVar("_log_callback", default=None)
+
 logger.level("DEBUG", color="")
 logger.level("INFO", color="<green>")
 logger.remove()
-logger.add(sys.stdout, colorize=True, format=LOGGER_FORMAT)
+
+
+def _private_sink(msg):
+    """Permanent sink that routes formatted output based on context variable."""
+    cb = _log_callback.get()
+    if cb is not None:
+        cb(msg.rstrip())
+    else:
+        print(msg.rstrip())
+
+
+logger.add(sys.stdout, colorize=True, format=LOGGER_FORMAT,
+           filter=lambda record: not record["extra"].get("_routed", False))
+logger.add(_private_sink, colorize=True, format=_PRIVATE_LOGGER_FORMAT,
+           filter=lambda record: record["extra"].get("_routed", False))
 
 
 def _get_bind(last=1):
+    """Walk the stack to get the real caller's module, function, and line."""
     frame = inspect.currentframe()
     try:
-        # Get the caller's frame
         for _ in range(last + 1):
             frame = frame.f_back
         name = frame.f_globals["__name__"]
@@ -32,43 +48,37 @@ def _get_bind(last=1):
         del frame
 
 
-def _log(logger_callback, sink_callback, message: str):
-    with io.StringIO() as string:
-        logger.remove()
-        logger.add(string, colorize=True, format=_PRIVATE_LOGGER_FORMAT)
-        logger_callback(message)
-        logger.remove()
-        logger.add(sys.stdout, colorize=True, format=LOGGER_FORMAT)
-        formatted_massage = string.getvalue().rstrip()
-    if sink_callback is None:
-        print(formatted_massage)
-    else:
-        sink_callback(formatted_massage)
+def _log(level: str, sink_callback, bind: dict, message: str):
+    token = _log_callback.set(sink_callback)
+    try:
+        logger.bind(_routed=True, **bind).log(level, message)
+    finally:
+        _log_callback.reset(token)
 
 
 def trace(message: str, callback=None):
-    _log(logger.bind(**_get_bind()).trace, callback, message)
+    _log("TRACE", callback, _get_bind(), message)
 
 
 def debug(message: str, callback=None):
-    _log(logger.bind(**_get_bind()).debug, callback, message)
+    _log("DEBUG", callback, _get_bind(), message)
 
 
 def info(message: str, callback=None):
-    _log(logger.bind(**_get_bind()).info, callback, message)
+    _log("INFO", callback, _get_bind(), message)
 
 
 def success(message: str, callback=None):
-    _log(logger.bind(**_get_bind()).success, callback, message)
+    _log("SUCCESS", callback, _get_bind(), message)
 
 
 def warning(message: str, callback=None):
-    _log(logger.bind(**_get_bind()).warning, callback, message)
+    _log("WARNING", callback, _get_bind(), message)
 
 
 def error(message: str, callback=None):
-    _log(logger.bind(**_get_bind()).error, callback, message)
+    _log("ERROR", callback, _get_bind(), message)
 
 
 def critical(message: str, callback=None):
-    _log(logger.bind(**_get_bind()).critical, callback, message)
+    _log("CRITICAL", callback, _get_bind(), message)

--- a/lib/multiprocess.py
+++ b/lib/multiprocess.py
@@ -4,17 +4,24 @@ import traceback
 from torch.multiprocessing import Manager, Process, get_context
 
 
+class FailedItem:
+    """Sentinel placed on the queue when a worker fails to process an item."""
+    __slots__ = ("exception", "traceback_str")
+
+    def __init__(self, exception: Exception, tb: str):
+        self.exception = exception
+        self.traceback_str = tb
+
+
 def chunked_worker_run(map_func, args, results_queue=None):
     for a in args:
-        # noinspection PyBroadException
         try:
             res = map_func(*a)
             results_queue.put(res)
         except KeyboardInterrupt:
             break
-        except Exception:
-            traceback.print_exc()
-            results_queue.put(None)
+        except Exception as exc:
+            results_queue.put(FailedItem(exc, traceback.format_exc()))
 
 
 def chunked_multiprocess_run(map_func, args, num_workers, q_max_size=1000):

--- a/lib/multiprocess.py
+++ b/lib/multiprocess.py
@@ -9,7 +9,7 @@ class FailedItem:
     __slots__ = ("exception", "traceback_str")
 
     def __init__(self, exception: Exception, tb: str):
-        self.exception = exception
+        self.exception = repr(exception)
         self.traceback_str = tb
 
 

--- a/lib/reflection.py
+++ b/lib/reflection.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import torch.optim
 
-from .config.schema import LRSchedulerConfig, OptimizerConfig
+from .config.schema import LRSchedulerConfig, OptimizerConfig, _walk_lr_scheduler_configs
 
 
 def get_object_by_module_path(path: str):
@@ -72,25 +72,13 @@ def build_lr_scheduler_from_config(
     """
     Build a learning rate scheduler from a configuration object, recursively.
     """
-    kwargs = {}
-    for key, value in config.kwargs.items():
-        if isinstance(value, LRSchedulerConfig):
-            value = build_lr_scheduler_from_config(optimizer, value)
-        elif isinstance(value, list):
-            value = [
-                build_lr_scheduler_from_config(optimizer, item) if isinstance(item, LRSchedulerConfig) else item
-                for item in value
-            ]
-        elif isinstance(value, dict):
-            value = {
-                k: build_lr_scheduler_from_config(optimizer, v) if isinstance(v, LRSchedulerConfig) else v
-                for k, v in value.items()
-            }
-        kwargs[key] = value
-    scheduler = build_object_from_class_name(
+    kwargs = _walk_lr_scheduler_configs(
+        config.kwargs,
+        lambda cfg: build_lr_scheduler_from_config(optimizer, cfg),
+    )
+    return build_object_from_class_name(
         config.cls,
         torch.optim.lr_scheduler.LRScheduler,
         optimizer=optimizer,
         **kwargs
     )
-    return scheduler

--- a/modules/functional.py
+++ b/modules/functional.py
@@ -38,7 +38,7 @@ def format_boundaries(
         durations: Tensor,
         length: int | Tensor,
         timestep: float,
-) -> tuple[Tensor, Tensor]:
+) -> Tensor:
     boundary_indices = durations.cumsum(dim=1).div(timestep).round().long().unsqueeze(1)  # [B, 1, N]
     indices = torch.arange(length, dtype=torch.long, device=durations.device)[None, ..., None]  # [1, T, 1]
     boundaries = (indices == boundary_indices[..., :-1]).any(dim=2)  # [B, T]

--- a/preprocessing/api.py
+++ b/preprocessing/api.py
@@ -1,7 +1,7 @@
 import pathlib
 
 from lib import logging
-from lib.config.formatter import ModelFormatter
+from lib.config.formatter import format_model
 from lib.config.io import load_raw_config
 from lib.config.schema import BinarizerConfig, RootConfig
 from preprocessing.binarizer_base import BaseBinarizer
@@ -21,8 +21,7 @@ def load_config_for_binarization(
     config = RootConfig.model_validate(config, scope=scope)
     config.resolve(scope_mask=scope)
     config.check(scope_mask=scope)
-    formatter = ModelFormatter()
-    print(formatter.format(config.binarizer))
+    print(format_model(config.binarizer))
     return config.binarizer
 
 

--- a/preprocessing/binarizer_base.py
+++ b/preprocessing/binarizer_base.py
@@ -12,7 +12,7 @@ from lib import logging
 from lib.config.io import save_raw_config
 from lib.config.schema import BinarizerConfig
 from lib.indexed_dataset import IndexedDatasetBuilder
-from lib.multiprocess import chunked_multiprocess_run
+from lib.multiprocess import chunked_multiprocess_run, FailedItem
 from modules.commons.tts_modules import LengthRegulator
 
 ACCEPTED_AUDIO_FORMATS = {".wav", ".flac"}
@@ -112,6 +112,12 @@ class BaseBinarizer(abc.ABC):
         total_duration = 0
         with tqdm.tqdm(iterable, total=len(items), desc=f"Processing {prefix} items") as progress:
             for sample in progress:
+                if isinstance(sample, FailedItem):
+                    logging.error(
+                        f"Worker failed: {sample.exception}",
+                        callback=progress.write
+                    )
+                    continue
                 sample: DataSample
                 if sample.error:
                     logging.error(

--- a/preprocessing/binarizer_base.py
+++ b/preprocessing/binarizer_base.py
@@ -114,7 +114,7 @@ class BaseBinarizer(abc.ABC):
             for sample in progress:
                 if isinstance(sample, FailedItem):
                     logging.error(
-                        f"Worker failed: {sample.exception}",
+                        f"Worker failed: {sample.exception}\n{sample.traceback_str}",
                         callback=progress.write
                     )
                     continue

--- a/preprocessing/notes_binarizer.py
+++ b/preprocessing/notes_binarizer.py
@@ -2,7 +2,6 @@ import csv
 import pathlib
 from dataclasses import dataclass
 
-import dask
 import librosa
 import numpy
 import torch
@@ -84,7 +83,6 @@ class NotesBinarizer(BaseBinarizer):
             "scores": note_midi_interp,
             "presence": ~note_rest,
         }
-        data, length = dask.compute(data, length)
         return DataSample(
             path=item.waveform_fn.relative_to(self.data_dir).as_posix(),
             name=item.name,
@@ -92,12 +90,10 @@ class NotesBinarizer(BaseBinarizer):
             data=data,
         )
 
-    @dask.delayed
     def load_waveform(self, wav_fn: pathlib.Path):
         waveform, _ = librosa.load(wav_fn, sr=self.config.features.audio_sample_rate, mono=True)
         return waveform
 
-    @dask.delayed(nout=2)
     @torch.no_grad()
     def get_mel(self, waveform: numpy.ndarray):
         if self.mel_spec is None:
@@ -116,7 +112,6 @@ class NotesBinarizer(BaseBinarizer):
         ).squeeze(0).T.cpu().numpy()
         return mel, mel.shape[0]
 
-    @dask.delayed
     def sec_dur_to_frame_dur(self, dur_sec: numpy.ndarray, length: int):
         dur_cumsum = numpy.round(numpy.cumsum(dur_sec, axis=0) / self.timestep).astype(numpy.int64)
         dur_cumsum = numpy.clip(dur_cumsum, a_min=0, a_max=length)
@@ -124,17 +119,14 @@ class NotesBinarizer(BaseBinarizer):
         dur_frame = numpy.diff(dur_cumsum, axis=0, prepend=numpy.array([0]))
         return dur_frame
 
-    @dask.delayed
     def length_regulator(self, dur_frames: numpy.ndarray):
-        dur_frames = dur_frames[dur_frames > 0]  # Filter out zero-duration notes
+        dur_frames = dur_frames[dur_frames > 0]
         return self.lr(torch.from_numpy(dur_frames).long().unsqueeze(0)).squeeze(0).numpy()
 
-    @dask.delayed
     def regions_to_boundaries(self, regions: numpy.ndarray):
         boundaries = numpy.diff(regions, axis=0, prepend=numpy.array([1])) > 0
         return boundaries
 
-    @dask.delayed
     def interpolate_rest(self, note_midi: numpy.ndarray, note_rest: numpy.ndarray) -> numpy.ndarray:
         interp_func = interpolate.interp1d(
             numpy.where(~note_rest)[0], note_midi[~note_rest],

--- a/preprocessing/notes_binarizer.py
+++ b/preprocessing/notes_binarizer.py
@@ -120,7 +120,7 @@ class NotesBinarizer(BaseBinarizer):
         return dur_frame
 
     def length_regulator(self, dur_frames: numpy.ndarray):
-        dur_frames = dur_frames[dur_frames > 0]
+        dur_frames = dur_frames[dur_frames > 0]  # Filter out zero-duration notes
         return self.lr(torch.from_numpy(dur_frames).long().unsqueeze(0)).squeeze(0).numpy()
 
     def regions_to_boundaries(self, regions: numpy.ndarray):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@
 
 click
 colorednoise
-dask
 einops>=0.7.0
 h5py
 librosa

--- a/training/api.py
+++ b/training/api.py
@@ -8,7 +8,7 @@ from lightning_utilities.core.rank_zero import rank_zero_only
 
 from lib import logging
 from lib.config.core import ConfigBaseModel
-from lib.config.formatter import ModelFormatter
+from lib.config.formatter import format_model
 from lib.config.io import load_raw_config, save_raw_config
 from lib.config.schema import RootConfig, PeriodicCheckpointConfig, ExpressionCheckpointConfig
 
@@ -21,9 +21,8 @@ __all__ = [
 
 @rank_zero_only
 def _log_config(cfg: RootConfig):
-    formatter = ModelFormatter()
-    print(formatter.format(cfg.model))
-    print(formatter.format(cfg.training))
+    print(format_model(cfg.model))
+    print(format_model(cfg.training))
 
 
 def load_config_for_training(

--- a/training/api.py
+++ b/training/api.py
@@ -179,16 +179,9 @@ def train_model(
         callbacks.append(checkpoint)
     trainer = lightning.pytorch.Trainer(
         accelerator=training_config.trainer.accelerator,
-        # TODO: strategy
         strategy=get_strategy(
-            devices=training_config.trainer.devices,
-            num_nodes=training_config.trainer.num_nodes,
-            accelerator=training_config.trainer.accelerator,
-            strategy={
-                "name": training_config.trainer.strategy.name,
-                **training_config.trainer.strategy.kwargs,
-            },
-            precision=training_config.trainer.precision,
+            training_config.trainer.strategy.name,
+            **training_config.trainer.strategy.kwargs,
         ),
         devices=training_config.trainer.devices,
         num_nodes=training_config.trainer.num_nodes,

--- a/training/augmentation.py
+++ b/training/augmentation.py
@@ -1,23 +1,23 @@
-import abc
 import hashlib
 import math
 from dataclasses import dataclass
+from typing import ClassVar
 
 import colorednoise
 import librosa
 import numpy as np
 import scipy.signal
 import torch
+from pydantic import BaseModel, Field
 from torch import Tensor
 
 from lib.config.schema import AugmentationConfig
 
 __all__ = [
-    "AugmentationArgs",
     "generate_seed",
-    "generate_augmentation_args",
+    "build_augmentation_chain",
     "Augmentation",
-    "Compose",
+    "ComposedAugmentation",
     "ColoredNoise",
     "NaturalNoise",
     "RIRReverb",
@@ -25,183 +25,69 @@ __all__ = [
     "SpectrogramMasking",
     "WaveformAugmentationContext",
     "SpectrogramAugmentationContext",
-    "build_wav_transforms",
-    "build_spec_transforms",
 ]
-
-
-@dataclass
-class _NaturalNoiseArgs:
-    path: str
-    zoom: float
-    offset: float
-    scale: float
-
-
-@dataclass
-class AugmentationArgs:
-    colored_noise_exponent: float = None
-    colored_noise_factor: float = None
-    natural_noise_args: list[_NaturalNoiseArgs] = None
-    natural_noise_db: float = None
-    rir_kernel_path: str = None
-    pitch_shift: float = None
-    loudness_scale: float = None
-    time_mask_offset: float = None
-    time_mask_width: int = None
-    time_mask_std: float = None
-    freq_mask_offset: int = None
-    freq_mask_width: int = None
-    freq_mask_mean: float = None
-    freq_mask_std: float = None
-    spec_mask_intersect: bool = None
-
-
-@dataclass
-class WaveformAugmentationContext:
-    waveform: np.ndarray
-    sr: int
-    args: AugmentationArgs
-    deterministic: bool
-    index: int
-
-
-@dataclass
-class SpectrogramAugmentationContext:
-    spectrogram: Tensor
-    args: AugmentationArgs
-    deterministic: bool
-    index: int
 
 
 def generate_seed(strings: list[str]) -> int:
     text = "|".join(strings)
     hash_obj = hashlib.sha256(text.encode("utf8"))
-    hex_digest = hash_obj.hexdigest()
-    return int(hex_digest[:8], 16)
+    return int(hash_obj.hexdigest()[:8], 16)
 
 
-def generate_augmentation_args(
-        config: AugmentationConfig, generator: np.random.Generator = None,
-        destructive_only: bool = False,
-) -> AugmentationArgs:
-    if generator is None:
-        generator = np.random.default_rng()
+# ---------------------------------------------------------------------------
+# Context dataclasses
+# ---------------------------------------------------------------------------
 
-    args = AugmentationArgs()
+@dataclass
+class WaveformAugmentationContext:
+    waveform: np.ndarray
+    sr: int
 
-    if (
-            config.colored_noise.enabled
-            and generator.random() < config.colored_noise.prob
-    ):
-        args.colored_noise_exponent = generator.uniform(
-            config.colored_noise.min_exponent,
-            config.colored_noise.max_exponent,
-        )
-        args.colored_noise_factor = generator.uniform(-6, -1)
 
-    if (
-            config.natural_noise.enabled
-            and generator.random() < config.natural_noise.prob
-    ):
-        natural_noise_args_list = []
-        repeats = generator.integers(1, config.natural_noise.max_repeats + 1)
-        for _ in range(repeats):
-            noise_path = generator.choice(config.natural_noise.noise_file_list)
-            noise_zoom = 2 ** generator.uniform(-1, 1)
-            noise_offset = generator.uniform(0, 1)
-            noise_scale = 10 ** (generator.uniform(-12, 12) / 20)
-            noise_args = _NaturalNoiseArgs(
-                path=noise_path,
-                zoom=noise_zoom,
-                offset=noise_offset,
-                scale=noise_scale,
-            )
-            natural_noise_args_list.append(noise_args)
-        args.natural_noise_args = natural_noise_args_list
-        args.natural_noise_db = generator.uniform(-24, -6)
-
-    if (
-            config.rir_reverb.enabled
-            and generator.random() < config.rir_reverb.prob
-    ):
-        args.rir_kernel_path = generator.choice(config.rir_reverb.kernel_file_list)
-
-    if (
-            not destructive_only
-            and config.pitch_shifting.enabled
-            and generator.random() < config.pitch_shifting.prob
-    ):
-        args.pitch_shift = generator.uniform(
-            config.pitch_shifting.min_semitones,
-            config.pitch_shifting.max_semitones,
-        )
-
-    if (
-            not destructive_only
-            and config.loudness_scaling.enabled
-            and generator.random() < config.loudness_scaling.prob
-    ):
-        args.loudness_scale = generator.uniform(
-            config.loudness_scaling.min_db,
-            config.loudness_scaling.max_db,
-        )
-
-    if config.spectrogram_masking.enabled:
-        time_masked = generator.random() < config.spectrogram_masking.time_mask_prob
-        freq_masked = generator.random() < config.spectrogram_masking.freq_mask_prob
-        if time_masked:
-            args.time_mask_offset = generator.uniform(0, 1)
-            args.time_mask_width = generator.integers(
-                1,
-                config.spectrogram_masking.time_mask_max_width + 1,
-            )
-            args.time_mask_std = generator.uniform(0, 1)
-        if freq_masked:
-            args.freq_mask_width = generator.integers(
-                1,
-                config.spectrogram_masking.freq_mask_max_width + 1,
-            )
-            args.freq_mask_offset = generator.integers(
-                0,
-                config.features.spectrogram.num_bins - args.freq_mask_width + 1,
-            )
-            args.freq_mask_mean = generator.uniform(math.log(1e-5), 0)
-            args.freq_mask_std = generator.uniform(0, 1)
-        if time_masked and freq_masked and generator.random() < config.spectrogram_masking.intersect_prob:
-            args.spec_mask_intersect = True
-    return args
+@dataclass
+class SpectrogramAugmentationContext:
+    spectrogram: Tensor
 
 
 # ---------------------------------------------------------------------------
 # Base classes
 # ---------------------------------------------------------------------------
 
-class Augmentation(abc.ABC):
+class Augmentation(BaseModel):
     """Base class for a single augmentation step."""
 
-    @abc.abstractmethod
-    def should_apply(self, ctx) -> bool: ...
+    _namespace: ClassVar[str] = ""
 
-    @abc.abstractmethod
-    def apply(self, ctx) -> None: ...
+    def should_apply(self) -> bool:
+        raise NotImplementedError
 
-    def __call__(self, ctx):
-        if self.should_apply(ctx):
-            self.apply(ctx)
-        return ctx
+    def apply(self, ctx) -> None:
+        raise NotImplementedError
+
+    def args_dict(self) -> dict:
+        data = self.model_dump(exclude_none=True)
+        if not data:
+            return {}
+        return {self._namespace: data}
 
 
-class Compose:
-    """Runs a sequence of augmentations in order."""
+class ComposedAugmentation(Augmentation):
+    """Chain of augmentations applied in sequence."""
 
-    def __init__(self, transforms: list[Augmentation]):
-        self.transforms = transforms
+    transforms: list[Augmentation] = Field(default_factory=list)
 
-    def __call__(self, ctx):
+    def should_apply(self) -> bool:
+        return bool(self.transforms)
+
+    def apply(self, ctx) -> None:
         for t in self.transforms:
-            t(ctx)
-        return ctx
+            t.apply(ctx)
+
+    def args_dict(self) -> dict:
+        result = {}
+        for t in self.transforms:
+            result.update(t.args_dict())
+        return result
 
 
 # ---------------------------------------------------------------------------
@@ -209,32 +95,76 @@ class Compose:
 # ---------------------------------------------------------------------------
 
 class ColoredNoise(Augmentation):
-    def should_apply(self, ctx: WaveformAugmentationContext) -> bool:
-        return ctx.args.colored_noise_exponent is not None
+    _namespace: ClassVar[str] = "colored_noise"
+
+    exponent: float = None
+    factor: float = None
+    seed: int | None = None
+
+    def __init__(self, config: AugmentationConfig, generator: np.random.Generator, **kwargs):
+        super().__init__(**kwargs)
+        if (
+                config.colored_noise.enabled
+                and generator.random() < config.colored_noise.prob
+        ):
+            self.exponent = generator.uniform(
+                config.colored_noise.min_exponent,
+                config.colored_noise.max_exponent,
+            )
+            self.factor = generator.uniform(-6, -1)
+            self.seed = int(generator.integers(0, 2 ** 31))
+
+    def should_apply(self) -> bool:
+        return self.exponent is not None
 
     def apply(self, ctx: WaveformAugmentationContext) -> None:
-        seed = ctx.index if ctx.deterministic else None
-        generator = np.random.default_rng(seed)
+        rng = np.random.default_rng(self.seed)
         noise = colorednoise.powerlaw_psd_gaussian(
-            ctx.args.colored_noise_exponent,
-            size=len(ctx.waveform),
-            random_state=generator,
+            self.exponent, size=len(ctx.waveform), random_state=rng,
         ).astype(np.float32)
-        ctx.waveform = ctx.waveform + noise * (10 ** ctx.args.colored_noise_factor)
+        ctx.waveform = ctx.waveform + noise * (10 ** self.factor)
 
 
 class NaturalNoise(Augmentation):
-    def should_apply(self, ctx: WaveformAugmentationContext) -> bool:
-        return ctx.args.natural_noise_args is not None
+    _namespace: ClassVar[str] = "natural_noise"
+
+    class _Item(BaseModel):
+        path: str
+        zoom: float
+        offset: float
+        scale: float
+
+    items: list[_Item] = None
+    db: float = None
+
+    def __init__(self, config: AugmentationConfig, generator: np.random.Generator, **kwargs):
+        super().__init__(**kwargs)
+        if (
+                config.natural_noise.enabled
+                and generator.random() < config.natural_noise.prob
+        ):
+            items = []
+            repeats = generator.integers(1, config.natural_noise.max_repeats + 1)
+            for _ in range(repeats):
+                items.append(NaturalNoise._Item(
+                    path=generator.choice(config.natural_noise.noise_file_list),
+                    zoom=2 ** generator.uniform(-1, 1),
+                    offset=generator.uniform(0, 1),
+                    scale=10 ** (generator.uniform(-12, 12) / 20),
+                ))
+            self.items = items
+            self.db = generator.uniform(-24, -6)
+
+    def should_apply(self) -> bool:
+        return self.items is not None
 
     def apply(self, ctx: WaveformAugmentationContext) -> None:
         total_noise = np.zeros_like(ctx.waveform)
-        for noise_args in ctx.args.natural_noise_args:
-            reinterpreted_sr = round(ctx.sr * noise_args.zoom)
-            noise, _ = librosa.load(noise_args.path, sr=reinterpreted_sr, mono=True)
-            min_offset = -len(noise)
-            max_offset = len(ctx.waveform)
-            offset = int(noise_args.offset * (max_offset - min_offset) + min_offset)
+        for item in self.items:
+            reinterpreted_sr = round(ctx.sr * item.zoom)
+            noise, _ = librosa.load(item.path, sr=reinterpreted_sr, mono=True)
+            offset_range = len(ctx.waveform) + len(noise)
+            offset = int(item.offset * offset_range - len(noise))
             if offset < 0:
                 noise = noise[-offset:]
             elif offset > 0:
@@ -243,25 +173,37 @@ class NaturalNoise(Augmentation):
                 noise = np.pad(noise, (0, len(ctx.waveform) - len(noise)), mode="constant")
             elif len(noise) > len(ctx.waveform):
                 noise = noise[:len(ctx.waveform)]
-            noise = noise * noise_args.scale
+            noise = noise * item.scale
             total_noise += noise
         scale = np.abs(ctx.waveform).max() / (np.abs(total_noise).max() + 1e-8)
         ctx.waveform = (
-            ctx.waveform + total_noise * scale * (10 ** (ctx.args.natural_noise_db / 20))
+                ctx.waveform + total_noise * scale * (10 ** (self.db / 20))
         ).astype(np.float32)
 
 
 class RIRReverb(Augmentation):
-    def should_apply(self, ctx: WaveformAugmentationContext) -> bool:
-        return ctx.args.rir_kernel_path is not None
+    _namespace: ClassVar[str] = "rir_reverb"
+
+    kernel_path: str = None
+
+    def __init__(self, config: AugmentationConfig, generator: np.random.Generator, **kwargs):
+        super().__init__(**kwargs)
+        if (
+                config.rir_reverb.enabled
+                and generator.random() < config.rir_reverb.prob
+        ):
+            self.kernel_path = generator.choice(config.rir_reverb.kernel_file_list)
+
+    def should_apply(self) -> bool:
+        return self.kernel_path is not None
 
     def apply(self, ctx: WaveformAugmentationContext) -> None:
-        rir, _ = librosa.load(ctx.args.rir_kernel_path, sr=ctx.sr, mono=True)
+        rir, _ = librosa.load(self.kernel_path, sr=ctx.sr, mono=True)
         convolved = scipy.signal.fftconvolve(
-            ctx.waveform, rir, mode="full"
+            ctx.waveform, rir, mode="full",
         ).astype(np.float32)
         rir_max = np.abs(rir).argmax()
-        convolved = convolved[rir_max: rir_max + len(ctx.waveform)]
+        convolved = convolved[rir_max:rir_max + len(ctx.waveform)]
         scale = np.abs(ctx.waveform).max() / (np.abs(convolved).max() + 1e-8)
         ctx.waveform = (convolved * scale).astype(np.float32)
 
@@ -271,56 +213,102 @@ class RIRReverb(Augmentation):
 # ---------------------------------------------------------------------------
 
 class LoudnessScaling(Augmentation):
-    def should_apply(self, ctx: SpectrogramAugmentationContext) -> bool:
-        return ctx.args.loudness_scale is not None
+    _namespace: ClassVar[str] = "loudness_scaling"
+
+    scale: float = None
+
+    def __init__(self, config: AugmentationConfig, generator: np.random.Generator, **kwargs):
+        super().__init__(**kwargs)
+        if (
+                config.loudness_scaling.enabled
+                and generator.random() < config.loudness_scaling.prob
+        ):
+            self.scale = generator.uniform(
+                config.loudness_scaling.min_db,
+                config.loudness_scaling.max_db,
+            )
+
+    def should_apply(self) -> bool:
+        return self.scale is not None
 
     def apply(self, ctx: SpectrogramAugmentationContext) -> None:
-        ctx.spectrogram = ctx.spectrogram + (ctx.args.loudness_scale / 20.0) * math.log(10)
+        ctx.spectrogram = ctx.spectrogram + (self.scale / 20.0) * math.log(10)
 
 
 class SpectrogramMasking(Augmentation):
-    def should_apply(self, ctx: SpectrogramAugmentationContext) -> bool:
-        return ctx.args.time_mask_width is not None or ctx.args.freq_mask_width is not None
+    _namespace: ClassVar[str] = "spectrogram_masking"
+
+    time_mask_offset: float = None
+    time_mask_width: int = None
+    time_mask_std: float = None
+    freq_mask_offset: int = None
+    freq_mask_width: int = None
+    freq_mask_mean: float = None
+    freq_mask_std: float = None
+    intersect: bool = None
+    seed: int | None = None
+
+    def __init__(self, config: AugmentationConfig, generator: np.random.Generator, **kwargs):
+        super().__init__(**kwargs)
+        if config.spectrogram_masking.enabled:
+            time_masked = generator.random() < config.spectrogram_masking.time_mask_prob
+            freq_masked = generator.random() < config.spectrogram_masking.freq_mask_prob
+            if time_masked:
+                self.time_mask_offset = generator.uniform(0, 1)
+                self.time_mask_width = int(generator.integers(
+                    1, config.spectrogram_masking.time_mask_max_width + 1,
+                ))
+                self.time_mask_std = generator.uniform(0, 1)
+            if freq_masked:
+                self.freq_mask_width = int(generator.integers(
+                    1, config.spectrogram_masking.freq_mask_max_width + 1,
+                ))
+                self.freq_mask_offset = int(generator.integers(
+                    0, config.features.spectrogram.num_bins - self.freq_mask_width + 1,
+                ))
+                self.freq_mask_mean = generator.uniform(math.log(1e-5), 0)
+                self.freq_mask_std = generator.uniform(0, 1)
+            if time_masked and freq_masked and generator.random() < config.spectrogram_masking.intersect_prob:
+                self.intersect = True
+            if self.time_mask_width is not None or self.freq_mask_width is not None:
+                self.seed = int(generator.integers(0, 2 ** 31))
+
+    def should_apply(self) -> bool:
+        return self.time_mask_width is not None or self.freq_mask_width is not None
 
     def apply(self, ctx: SpectrogramAugmentationContext) -> None:
-        args = ctx.args
-        seed = ctx.index if ctx.deterministic else None
-        generator = np.random.default_rng(seed)
+        rng = np.random.default_rng(self.seed)
         T, C = ctx.spectrogram.shape
         spec = ctx.spectrogram.cpu().numpy()
-        time_masked = args.time_mask_width is not None
-        freq_masked = args.freq_mask_width is not None
+        time_masked = self.time_mask_width is not None
+        freq_masked = self.freq_mask_width is not None
+        time_mask_start = time_mask_end = time_mask_width = None
+        freq_mask_start = freq_mask_end = None
         if time_masked:
-            time_mask_width = min(args.time_mask_width, T)
-            time_offset_max = T - time_mask_width
-            time_mask_start = int(args.time_mask_offset * time_offset_max)
+            time_mask_width = min(self.time_mask_width, T)
+            time_mask_start = int(self.time_mask_offset * (T - time_mask_width))
             time_mask_end = time_mask_start + time_mask_width
-        else:
-            time_mask_start = time_mask_end = None
-            time_mask_width = None
         if freq_masked:
-            freq_mask_start = args.freq_mask_offset
-            freq_mask_end = args.freq_mask_offset + args.freq_mask_width
-        else:
-            freq_mask_start = freq_mask_end = None
-        if time_masked and freq_masked and args.spec_mask_intersect:
+            freq_mask_start = self.freq_mask_offset
+            freq_mask_end = self.freq_mask_offset + self.freq_mask_width
+        if time_masked and freq_masked and self.intersect:
             spec[time_mask_start:time_mask_end, freq_mask_start:freq_mask_end] = (
-                generator.standard_normal(
-                    size=(time_mask_width, args.freq_mask_width), dtype=np.float32
-                ) * args.freq_mask_std + args.freq_mask_mean
+                    rng.standard_normal(
+                        size=(time_mask_width, self.freq_mask_width), dtype=np.float32,
+                    ) * self.freq_mask_std + self.freq_mask_mean
             )
         else:
             if time_masked:
                 spec[time_mask_start:time_mask_end, :] = (
-                    generator.standard_normal(
-                        size=(time_mask_width, C), dtype=np.float32
-                    ) * args.time_mask_std
+                        rng.standard_normal(
+                            size=(time_mask_width, C), dtype=np.float32,
+                        ) * self.time_mask_std
                 )
             if freq_masked:
                 spec[:, freq_mask_start:freq_mask_end] = (
-                    generator.standard_normal(
-                        size=(T, args.freq_mask_width), dtype=np.float32
-                    ) * args.freq_mask_std + args.freq_mask_mean
+                        rng.standard_normal(
+                            size=(T, self.freq_mask_width), dtype=np.float32,
+                        ) * self.freq_mask_std + self.freq_mask_mean
                 )
         ctx.spectrogram = torch.from_numpy(spec).to(ctx.spectrogram.device)
 
@@ -329,24 +317,42 @@ class SpectrogramMasking(Augmentation):
 # Chain construction
 # ---------------------------------------------------------------------------
 
-def build_wav_transforms(config: AugmentationConfig) -> Compose:
-    transforms = []
-    if config.rir_reverb.enabled:
-        transforms.append(RIRReverb())
-    if config.colored_noise.enabled:
-        transforms.append(ColoredNoise())
-    if config.natural_noise.enabled:
-        transforms.append(NaturalNoise())
-    return Compose(transforms)
-
-
-def build_spec_transforms(
+def build_augmentation_chain(
         config: AugmentationConfig,
+        generator: np.random.Generator,
         destructive_only: bool = False,
-) -> Compose:
-    transforms = []
-    if not destructive_only and config.loudness_scaling.enabled:
-        transforms.append(LoudnessScaling())
-    if config.spectrogram_masking.enabled:
-        transforms.append(SpectrogramMasking())
-    return Compose(transforms)
+) -> tuple[ComposedAugmentation, float | None, ComposedAugmentation]:
+    """Build (wav_chain, pitch_shift, spec_chain) for a single sample."""
+    wav_transforms: list[Augmentation] = []
+    for aug in [
+        ColoredNoise(config=config, generator=generator),
+        NaturalNoise(config=config, generator=generator),
+        RIRReverb(config=config, generator=generator),
+    ]:
+        if aug.should_apply():
+            wav_transforms.append(aug)
+
+    pitch_shift: float | None = None
+    if not destructive_only:
+        if (
+                config.pitch_shifting.enabled
+                and generator.random() < config.pitch_shifting.prob
+        ):
+            pitch_shift = float(generator.uniform(
+                config.pitch_shifting.min_semitones,
+                config.pitch_shifting.max_semitones,
+            ))
+
+    spec_transforms: list[Augmentation] = []
+    for aug in [
+        LoudnessScaling(config=config, generator=generator),
+        SpectrogramMasking(config=config, generator=generator),
+    ]:
+        if aug.should_apply():
+            spec_transforms.append(aug)
+
+    return (
+        ComposedAugmentation(transforms=wav_transforms),
+        pitch_shift,
+        ComposedAugmentation(transforms=spec_transforms),
+    )

--- a/training/callbacks.py
+++ b/training/callbacks.py
@@ -165,7 +165,7 @@ class ExpressionModelCheckpoint(FriendlyModelCheckpoint):
             trainer: lightning.pytorch.Trainer,
             monitor_candidates: dict[str, torch.Tensor]
     ) -> None:
-        missing = set(self.expression.free_symbols) - monitor_candidates.keys()
+        missing = {s.name for s in self.expression.free_symbols} - monitor_candidates.keys()
         if missing:
             raise ValueError(
                 f"Expression '{self.expression}' references unknown metrics {missing}. "

--- a/training/callbacks.py
+++ b/training/callbacks.py
@@ -165,11 +165,17 @@ class ExpressionModelCheckpoint(FriendlyModelCheckpoint):
             trainer: lightning.pytorch.Trainer,
             monitor_candidates: dict[str, torch.Tensor]
     ) -> None:
+        missing = set(self.expression.free_symbols) - monitor_candidates.keys()
+        if missing:
+            raise ValueError(
+                f"Expression '{self.expression}' references unknown metrics {missing}. "
+                f"Available metrics: {sorted(monitor_candidates.keys())}"
+            )
         eval_result = self.expression.evalf(subs=monitor_candidates)
         if not isinstance(eval_result, sympy.Number):
             raise ValueError(
                 f"Expression '{self.expression}' not fully evaluated. "
-                f"Valid candidates: {list(monitor_candidates.keys())}"
+                f"Available metrics: {sorted(monitor_candidates.keys())}"
             )
         eval_result = torch.tensor(float(eval_result), dtype=torch.float32)
         monitor_candidates[self.metric_key] = eval_result

--- a/training/callbacks.py
+++ b/training/callbacks.py
@@ -169,13 +169,13 @@ class ExpressionModelCheckpoint(FriendlyModelCheckpoint):
         if missing:
             raise ValueError(
                 f"Expression '{self.expression}' references unknown metrics {missing}. "
-                f"Available metrics: {sorted(monitor_candidates.keys())}"
+                f"Valid candidates: {sorted(monitor_candidates.keys())}"
             )
         eval_result = self.expression.evalf(subs=monitor_candidates)
         if not isinstance(eval_result, sympy.Number):
             raise ValueError(
                 f"Expression '{self.expression}' not fully evaluated. "
-                f"Available metrics: {sorted(monitor_candidates.keys())}"
+                f"Valid candidates: {sorted(monitor_candidates.keys())}"
             )
         eval_result = torch.tensor(float(eval_result), dtype=torch.float32)
         monitor_candidates[self.metric_key] = eval_result

--- a/training/data.py
+++ b/training/data.py
@@ -65,12 +65,9 @@ class BaseDataset(torch.utils.data.Dataset):
         self.wav_transforms = None
         self.mel_spectrogram = None
         self.spec_transforms = None
-        self.setup = False
+        self._setup()
 
     def __getitem__(self, index):
-        if not self.setup:
-            self._setup()
-            self.setup = True
         sample = self.data[index]
         spectrogram = sample["spectrogram"]
         augmentation = {}

--- a/training/data.py
+++ b/training/data.py
@@ -1,4 +1,3 @@
-import dataclasses
 import math
 import pathlib
 
@@ -10,9 +9,9 @@ from lib.config.schema import AugmentationConfig
 from lib.feature.mel import StretchableMelSpectrogram
 from lib.indexed_dataset import IndexedDataset
 from .augmentation import (
-    AugmentationArgs, WaveformAugmentationContext, SpectrogramAugmentationContext,
-    generate_seed, generate_augmentation_args,
-    build_wav_transforms, build_spec_transforms,
+    WaveformAugmentationContext, SpectrogramAugmentationContext,
+    ComposedAugmentation,
+    generate_seed, build_augmentation_chain,
 )
 
 __all__ = [
@@ -61,10 +60,8 @@ class BaseDataset(torch.utils.data.Dataset):
         self.augmentation_deterministic = augmentation_deterministic
         self.augmentation_destructive_only = augmentation_destructive_only
         self.augmentation_return_dirty = augmentation_return_dirty
-        self.augmentation_args_map: dict[int, AugmentationArgs] = {}
-        self.wav_transforms = None
+        self.augmentation_chains: dict[int, tuple[ComposedAugmentation, float | None, ComposedAugmentation]] = {}
         self.mel_spectrogram = None
-        self.spec_transforms = None
         self._setup()
 
     def __getitem__(self, index):
@@ -72,17 +69,26 @@ class BaseDataset(torch.utils.data.Dataset):
         spectrogram = sample["spectrogram"]
         augmentation = {}
         if self.augmentation_config is not None:
-            augmentation_args = self.augmentation_args_map.get(index)
-            if augmentation_args is None:
-                # Must be indeterministic if augmentation args are not pre-generated
-                augmentation_args = generate_augmentation_args(
+            pipeline = self.augmentation_chains.get(index)
+            if pipeline is None:
+                wav_chain, pitch_shift, spec_chain = build_augmentation_chain(
                     self.augmentation_config,
+                    generator=numpy.random.default_rng(),
                     destructive_only=self.augmentation_destructive_only,
                 )
+            else:
+                wav_chain, pitch_shift, spec_chain = pipeline
             # Apply augmentations to spectrogram
-            spectrogram = self._get_augmented_spectrogram(index, spectrogram, augmentation_args)
-            # Convert augmentation args to dict for pickling
-            augmentation = dataclasses.asdict(augmentation_args)
+            spectrogram = self._get_augmented_spectrogram(
+                index, spectrogram, wav_chain, pitch_shift, spec_chain,
+            )
+            # Build serializable dict
+            augmentation = {
+                **wav_chain.args_dict(),
+                **spec_chain.args_dict(),
+            }
+            if pitch_shift is not None:
+                augmentation["pitch_shifting"] = {"shift": pitch_shift}
         spectrogram = torch.clamp(spectrogram, min=math.log(1e-5))
         if self.augmentation_return_dirty:
             sample["spectrogram"] = torch.clamp(sample["spectrogram"], min=math.log(1e-5))
@@ -118,20 +124,15 @@ class BaseDataset(torch.utils.data.Dataset):
             fmax=self.augmentation_config.features.spectrogram.fmax,
             clip_val=1e-9,
         ).eval()
-        self.wav_transforms = build_wav_transforms(self.augmentation_config)
-        self.spec_transforms = build_spec_transforms(
-            self.augmentation_config,
-            destructive_only=self.augmentation_destructive_only,
-        )
         if self.augmentation_deterministic:
-            # Pre-generate augmentation args for each sample
             seed = generate_seed(sorted(self.info.keys()))
             generator = numpy.random.default_rng(seed)
             for index in range(len(self)):
-                self.augmentation_args_map[index] = generate_augmentation_args(
+                wav_chain, pitch_shift, spec_chain = build_augmentation_chain(
                     self.augmentation_config, generator=generator,
                     destructive_only=self.augmentation_destructive_only,
                 )
+                self.augmentation_chains[index] = (wav_chain, pitch_shift, spec_chain)
 
     def _get_waveform(self, index):
         # Load original waveform
@@ -141,55 +142,41 @@ class BaseDataset(torch.utils.data.Dataset):
         )
         return waveform
 
-    def _get_augmented_spectrogram(self, index, spectrogram: torch.Tensor, args: AugmentationArgs) -> torch.Tensor:
-        # Lazily load waveform only when a waveform-domain or wav->mel transform is active
-        waveform_needed = any([
-            args.rir_kernel_path is not None,
-            args.colored_noise_exponent is not None,
-            args.natural_noise_args is not None,
-            args.pitch_shift is not None,
-        ])
+    def _get_augmented_spectrogram(
+            self, index, spectrogram: torch.Tensor,
+            wav_chain: ComposedAugmentation,
+            pitch_shift: float | None,
+            spec_chain: ComposedAugmentation
+    ) -> torch.Tensor:
+        waveform_needed = wav_chain.should_apply() or pitch_shift is not None
         if waveform_needed:
             waveform = self._get_waveform(index)
         else:
             waveform = None
 
         # Stage 1: wav -> wav
-        if waveform is not None and len(self.wav_transforms.transforms) > 0:
+        if waveform is not None:
             ctx = WaveformAugmentationContext(
                 waveform=waveform,
                 sr=self.augmentation_config.features.audio_sample_rate,
-                args=args,
-                deterministic=self.augmentation_deterministic,
-                index=index,
             )
-            self.wav_transforms(ctx)
+            wav_chain.apply(ctx)
             waveform = ctx.waveform
 
         # Stage 2: wav -> mel
         if waveform is not None:
             waveform_tensor = torch.from_numpy(waveform).unsqueeze(0)
-            if (
-                    self.augmentation_config.pitch_shifting.enabled
-                    and not self.augmentation_destructive_only
-                    and args.pitch_shift is not None
-            ):
+            if pitch_shift is not None and not self.augmentation_destructive_only:
                 spectrogram = self.mel_spectrogram(
-                    waveform_tensor, key_shift=args.pitch_shift,
+                    waveform_tensor, key_shift=pitch_shift,
                 ).squeeze(0).T
             else:
                 spectrogram = self.mel_spectrogram(waveform_tensor).squeeze(0).T
 
         # Stage 3: mel -> mel
-        if len(self.spec_transforms.transforms) > 0:
-            ctx = SpectrogramAugmentationContext(
-                spectrogram=spectrogram,
-                args=args,
-                deterministic=self.augmentation_deterministic,
-                index=index,
-            )
-            self.spec_transforms(ctx)
-            spectrogram = ctx.spectrogram
+        ctx = SpectrogramAugmentationContext(spectrogram=spectrogram)
+        spec_chain.apply(ctx)
+        spectrogram = ctx.spectrogram
 
         return spectrogram
 

--- a/training/me_module.py
+++ b/training/me_module.py
@@ -41,7 +41,7 @@ class MIDIExtractionDataset(BaseDataset):
         sample = super().__getitem__(index)
         sample["T"] = torch.tensor(sample["spectrogram"].shape[0], dtype=torch.long)
         sample["N"] = torch.tensor(sample["durations"].shape[0], dtype=torch.long)
-        if (pitch_shift := sample["_augmentation"].get("pitch_shift")) is not None:
+        if (pitch_shift := sample["_augmentation"].get("pitch_shifting", {}).get("shift")) is not None:
             sample["scores"] += pitch_shift
         return sample
 

--- a/training/pl_module_base.py
+++ b/training/pl_module_base.py
@@ -114,7 +114,7 @@ class BaseLightningModule(lightning.pytorch.LightningModule, abc.ABC):
             return
         param_dict = dict(self.named_parameters())
         size = len(param_dict)
-        _apply_include_exclude(
+        param_dict = _apply_include_exclude(
             param_dict,
             includes=self.training_config.finetuning.freezing_include_params,
             excludes=self.training_config.finetuning.freezing_exclude_params
@@ -129,7 +129,7 @@ class BaseLightningModule(lightning.pytorch.LightningModule, abc.ABC):
 
     def build_ema(self) -> ExponentialMovingAverage:
         parameters = dict(self.named_parameters())
-        _apply_include_exclude(
+        parameters = _apply_include_exclude(
             parameters,
             includes=self.training_config.weight_averaging.ema_include_params,
             excludes=self.training_config.weight_averaging.ema_exclude_params
@@ -146,7 +146,7 @@ class BaseLightningModule(lightning.pytorch.LightningModule, abc.ABC):
             pretrained_model_path, map_location=self.device, weights_only=True
         )
         source_state_dict = ckpt["state_dict"]
-        _apply_include_exclude(
+        source_state_dict = _apply_include_exclude(
             source_state_dict,
             includes=self.training_config.finetuning.pretraining_include_params,
             excludes=self.training_config.finetuning.pretraining_exclude_params
@@ -405,12 +405,15 @@ class BaseLightningModule(lightning.pytorch.LightningModule, abc.ABC):
             self.ema.load_state_dict(checkpoint.pop("ema_state_dict"), strict=True)
 
 
-def _apply_include_exclude(dict_to_filter: dict[str, Any], includes: list[str] = None, excludes: list[str] = None):
-    for key in list(dict_to_filter.keys()):
+def _apply_include_exclude(dict_to_filter: dict[str, Any], includes: list[str] = None, excludes: list[str] = None) -> dict[str, Any]:
+    result = {}
+    for key, value in dict_to_filter.items():
         if includes and not any(fnmatch(key, pattern) for pattern in includes):
-            del dict_to_filter[key]
-        elif excludes and any(fnmatch(key, pattern) for pattern in excludes):
-            del dict_to_filter[key]
+            continue
+        if excludes and any(fnmatch(key, pattern) for pattern in excludes):
+            continue
+        result[key] = value
+    return result
 
 
 def _check_shape_consistency(

--- a/training/strategy.py
+++ b/training/strategy.py
@@ -1,93 +1,20 @@
-import torch
+from lightning.pytorch.strategies import StrategyRegistry
 
 from lib.reflection import filter_kwargs_by_class
 
 
-def get_strategy(
-        devices="auto",
-        num_nodes=1,
-        accelerator="auto",
-        strategy={"name": "auto"},
-        precision=None,
-):
-    from lightning.fabric.utilities.device_parser import _determine_root_gpu_device
-    from lightning.pytorch.accelerators import AcceleratorRegistry
-    from lightning.pytorch.accelerators.cuda import CUDAAccelerator
-    from lightning.pytorch.accelerators.mps import MPSAccelerator
-    from lightning.pytorch.strategies import Strategy, SingleDeviceStrategy, StrategyRegistry
-    from lightning.pytorch.trainer.connectors import accelerator_connector
-    from lightning.pytorch.utilities.rank_zero import rank_zero_warn
+def get_strategy(name: str = "auto", **kwargs):
+    """Create a Lightning strategy instance from a name and keyword arguments."""
+    if name == "auto":
+        return "auto"
 
-    class _DsAcceleratorConnector(accelerator_connector._AcceleratorConnector):
-        def __init__(self) -> None:
-            register_fn = getattr(
-                accelerator_connector,
-                "_register_external_accelerators_and_strategies",
-                None,
-            )
-            if callable(register_fn):
-                register_fn()
+    if name not in StrategyRegistry:
+        available = ", ".join(sorted(StrategyRegistry.available_strategies())) or "none"
+        raise KeyError(
+            f"Invalid strategy name '{name}'. Available names: {available}"
+        )
 
-            self._registered_strategies = StrategyRegistry.available_strategies()
-            self._accelerator_types = AcceleratorRegistry.available_accelerators()
-            self._parallel_devices = []
-            self._check_config_and_set_final_flags(
-                strategy=strategy["name"],
-                accelerator=accelerator,
-                precision=precision,
-                plugins=[],
-                sync_batchnorm=False,
-            )
-            if self._accelerator_flag == "auto":
-                self._accelerator_flag = self._choose_auto_accelerator()
-            elif self._accelerator_flag == "gpu":
-                self._accelerator_flag = self._choose_gpu_accelerator_backend()
-            self._check_device_config_and_set_final_flags(devices=devices, num_nodes=num_nodes)
-            self._set_parallel_devices_and_init_accelerator()
-            if self._strategy_flag == "auto":
-                self._strategy_flag = self._choose_strategy()
-            self._check_strategy_and_fallback()
-            self._init_strategy()
-            for k in ["colossalai", "bagua", "hpu", "hpu_parallel", "hpu_single", "ipu", "ipu_strategy"]:
-                if k in StrategyRegistry:
-                    StrategyRegistry.remove(k)
-
-        def _init_strategy(self) -> None:
-            assert isinstance(self._strategy_flag, (str, Strategy))
-            if isinstance(self._strategy_flag, str):
-                if self._strategy_flag not in StrategyRegistry:
-                    available_names = ", ".join(sorted(StrategyRegistry.available_strategies())) or "none"
-                    raise KeyError(f"Invalid strategy name {strategy['name']}. Available names: {available_names}")
-                data = StrategyRegistry[self._strategy_flag]
-                params = {}
-                if issubclass(data["strategy"], SingleDeviceStrategy):
-                    if self._accelerator_flag == "hpu":
-                        params = {"device": torch.device("hpu")}
-                    elif self._accelerator_flag == "tpu":
-                        params = {"device": self._parallel_devices[0]}
-                    elif data["strategy"] is SingleDeviceStrategy:
-                        if isinstance(self._accelerator_flag, (CUDAAccelerator, MPSAccelerator)) or (
-                                isinstance(self._accelerator_flag, str) and self._accelerator_flag in ("cuda", "gpu", "mps")
-                        ):
-                            params = {"device": _determine_root_gpu_device(self._parallel_devices)}
-                        else:
-                            params = {"device": "cpu"}
-                    else:
-                        raise NotImplementedError
-                params.update(data["init_params"])
-                params.update({k: v for k, v in strategy.items() if k != "name"})
-                self.strategy = data["strategy"](**filter_kwargs_by_class(data["strategy"], params))
-            elif isinstance(self._strategy_flag, SingleDeviceStrategy):
-                params = {"device": self._strategy_flag.root_device}
-                params.update({k: v for k, v in strategy.items() if k != "name"})
-                self.strategy = self._strategy_flag.__class__(
-                    **filter_kwargs_by_class(self._strategy_flag.__class__, params)
-                )
-            else:
-                rank_zero_warn(
-                    f"Inferred strategy {self._strategy_flag.__class__.__name__} cannot take custom configurations."
-                    f"To use custom configurations, please specify the strategy name explicitly."
-                )
-                self.strategy = self._strategy_flag
-
-    return _DsAcceleratorConnector().strategy
+    data = StrategyRegistry[name]
+    strategy_cls = data["strategy"]
+    params = {**data.get("init_params", {}), **kwargs}
+    return strategy_cls(**filter_kwargs_by_class(strategy_cls, params))


### PR DESCRIPTION
# Code Smell Fixes — PR Summary

19 commits, 20 files changed.

---

## 1. Fix config scope detection via sentinel instead of try/except
**File:** `lib/config/core.py`  
**Smell:** Exception-driven control flow — `ContextVar.get()` raised `LookupError` as part of normal operation.  
**Fix:** Replaced `try/except LookupError` with a `_SCOPE_UNSET` sentinel object and `_current_scope.get(sentinel)` check.  
**Tested:** Config loading from `configs/midi.yaml` via `RootConfig.model_validate`.

## 2. Fix `_apply_include_exclude` to return new dict instead of mutating input
**File:** `training/pl_module_base.py`  
**Smell:** Mutation-by-side-effect — `_apply_include_exclude` modified the caller's dict in-place.  
**Fix:** Changed to return a new filtered dict. Updated 3 call sites (`freeze_parameters`, `build_ema`, `load_from_pretrained_model`).  
**Tested:** Config loading + model construction with `configs/midi.yaml`.

## 3. Fix thread-unsafe logger handler swapping with permanent sinks
**File:** `lib/logging.py`  
**Smell:** `logger.remove()` followed by `logger.add()` was not thread-safe — concurrent threads could interfere with each other's handlers.  
**Fix:** Two permanent sinks with `contextvars`-based routing. A `_routed` extra field on log records determines whether output goes to the caller's callback (via `ContextVar`) or stdout.  
**Tested:** Concurrent logging calls from multiple threads; verified messages route correctly.

## 4. Replace if/elif chains in config ops with dispatch dictionaries
**File:** `lib/config/ops.py`  
**Smell:** 20-branch `if/elif` chains in `BinaryOperation.resolve()`, `UnaryOperation.resolve()`, and `Aggregation.resolve()`.  
**Fix:** Three O(1) dispatch dicts (`_BINARY_OPS`, `_UNARY_OPS`, `_AGGREGATION_OPS`) mapping operator strings to Python `operator` functions.  
**Tested:** Config loading and resolution with nested `ref()`, `coalesce()`, `if_()` expressions.

## 5. Refactor ModelFormatter into stateless format_model function
**File:** `lib/config/formatter.py`  
**Smell:** Mutable-state `ModelFormatter` class masquerading as a function.  
**Fix:** Single stateless `format_model()` function with a `_Fmt` dataclass for transient state. Updated all 3 call sites.  
**Tested:** Config printing in training, preprocessing, and inference pipelines.

## 6. Replace hasattr-based dynamic attribute caching with Pydantic PrivateAttr
**File:** `lib/config/schema.py`  
**Smell:** `hasattr(self, "_noise_file_list")` and `hasattr(self, "_kernel_file_list")` for lazy-init-ed caches.  
**Fix:** `_noise_file_list` and `_kernel_file_list` declared as `PrivateAttr(default_factory=list)` in `NaturalNoiseAugmentationConfig` and `RIRReverbAugmentationConfig`.  
**Tested:** Config model construction and serialization (PrivateAttr excluded from `model_dump`).

## 7. Move BaseDataset setup from lazy init in `__getitem__` to `__init__`
**File:** `training/data.py`  
**Smell:** Lazy `_setup()` call guarded by unguarded `self.setup` flag in `__getitem__` — fragile under multi-worker DataLoader contexts.  
**Fix:** `_setup()` called at the end of `__init__`. Removed `self.setup` flag and `__getitem__` lazy-init guard.  
**Tested:** BaseDataset construction and item retrieval with `configs/midi.yaml`.

## 8. Refactor augmentation system with Chain of Responsibility pattern
**Files:** `training/augmentation.py`, `training/data.py`, `training/me_module.py`  
**Smell:** 100-line monolithic `generate_augmentation_args` + flat `AugmentationArgs` dataclass with 15 loosely-coupled optional fields.  
**Fix:**
- Each augmentation is a Pydantic model (`Augmentation` extends `BaseModel`) — its fields ARE its args.
- `__init__(config, generator)` populates args directly; no separate `generate_args` step.
- `ComposedAugmentation` chains only triggered transforms.
- Seed for apply-phase noise derived from the same generator (no external injection).
- Context dataclasses stripped to pure data carriers (`waveform`/`spectrogram` only).
- `AugmentationPlan` eliminated; `build_augmentation_chain` returns `(wav_chain, pitch_shift, spec_chain)`.
**Tested:** Full dataset pipeline (config load → BaseDataset → augmentation chain → `__getitem__`) with `configs/midi.yaml`; deterministic reproducibility verified.

## 9. Extract shared `_walk_lr_scheduler_configs` to eliminate duplicated recursion
**Files:** `lib/config/schema.py`, `lib/reflection.py`  
**Smell:** Both `LRSchedulerConfig.check_kwargs` and `build_lr_scheduler_from_config` recursively walked nested dicts/lists to find `LRSchedulerConfig` entries.  
**Fix:** Extracted `_walk_lr_scheduler_configs(obj, fn)` — a recursive walker that applies a function to each found config. Both call sites reduced to single expressions.  
**Tested:** `LRSchedulerConfig` validation with nested/listed/deeply-nested scheduler configs.

## 10. Validate sympy expression symbols before evaluating checkpoint metrics
**File:** `training/callbacks.py`  
**Smell:** `ExpressionModelCheckpoint._save_topk_checkpoint` called `sympy.evalf()` without validating that all free symbols exist in `monitor_candidates`, producing cryptic errors.  
**Fix:** Extract `self.expression.free_symbols` and compare against `monitor_candidates.keys()` before evaluation, with a clear error listing missing vs available metrics.  
**Tested:** `ExpressionModelCheckpoint` construction with valid symbols, composite expressions, and constant rejection.

## 11. Replace silent None sentinel with FailedItem on worker exceptions
**Files:** `lib/multiprocess.py`, `preprocessing/binarizer_base.py`  
**Smell:** `chunked_worker_run` silently put `None` on the queue for failed items, hiding which item failed and why.  
**Fix:** `FailedItem(exc, traceback_str)` sentinel placed on the queue. Consumer in `binarizer_base.py` checks `isinstance(sample, FailedItem)` and logs the error.  
**Tested:** Multiprocess worker exception path (injected failure via test script).

## 12. Remove dead dask abstraction from notes binarizer
**Files:** `preprocessing/notes_binarizer.py`, `binarize.py`, `requirements.txt`  
**Smell:** 6 methods decorated with `@dask.delayed`, but `dask.config.set(scheduler="synchronous")` and `dask.compute()` immediately forced synchronous execution — laziness never propagated.  
**Fix:** Removed all `@dask.delayed` decorators, `dask.compute()` call, `dask.config.set()`, and the `dask` import. Removed `dask` from `requirements.txt`.  
**Tested:** Binarizer module import and method resolution (no-op path verified).

## 13. Replace fragile Lightning internals monkey-patching with public StrategyRegistry API
**Files:** `training/strategy.py`, `training/api.py`  
**Smell:** `get_strategy()` subclassed Lightning's private `_AcceleratorConnector`, overrode `_init_strategy`, accessed private methods, and mutated the global `StrategyRegistry`.  
**Fix:** Replaced with direct use of Lightning 2.6.x public `StrategyRegistry` API. `get_strategy(name, **kwargs)` looks up the strategy class and instantiates it via `filter_kwargs_by_class`.  
**Tested:** Strategy construction for `auto`, `ddp`, `ddp`+`find_unused_parameters`, `fsdp`, `single_device`; invalid-name error handling.

## 14. Extract common `_export` helper to eliminate duplicated ONNX export logic
**File:** `deployment/exporter.py`  
**Smell:** All 4 export methods duplicated the same dynamo/non-dynamo branching, `torch.onnx.export` call, stacktrace clearing, and model slimming (~70 identical lines each).  
**Fix:** `_export(model, args, save_path, input_names, output_names, dynamic_axes, dynamic_shapes, kwargs)` helper consolidates the common pattern. Each export method reduced to ~20 lines of model construction + shape config.  
**Tested:** Modular structure verified; all 5 export targets (`encoder`, `segmenter`, `estimator`, `dur2bd`, `bd2dur`) preserved.

## 15. Centralize IndexedDataset HDF5 open logic with property and pickle safety
**File:** `lib/indexed_dataset.py`  
**Smell:** HDF5 file handle (`dset`) open logic duplicated in `__getitem__` and `__len__`; `check_index` assumed `dset` already open. Lazy open was intentional for multiprocessing but scattered across methods.  
**Fix:** Centralized lazy-open in a `@property dset` getter. Added `__getstate__` to clear `_dset` before pickle — each DataLoader worker re-opens its own file handle on first access. `__del__` reads `_dset` directly to avoid re-opening just to close.  
**Tested:** Normal access, pickle round-trip (verify `_dset` is `None` after unpickle, lazy re-open works), `__del__` on both opened and unopened datasets.

## 16. Extract shared config field walker to eliminate duplicated recursive traversal
**File:** `lib/config/core.py`  
**Smell:** `_resolve_recursive` and `_check_recursive` shared ~80% identical structure — both iterated ConfigBaseModel fields, handled nested models and lists, and managed the `current_path` stack. Only the leaf operation differed (resolve expression vs. run check).  
**Fix:** Extracted `_walk_config_fields(current, context, leaf_fn)` as the shared walker. Each original method is now a thin wrapper that passes its leaf operation as a closure.  
**Tested:** Config loading and resolution with nested `ref()`, `coalesce()`, `if_()` expressions via `configs/midi.yaml`.

## 17. Fix `format_boundaries` return type annotation
**File:** `modules/functional.py`  
**Smell:** The function was annotated as returning `tuple[Tensor, Tensor]` but returns a single `Tensor`. Type checkers would flag every call site.  
**Fix:** Corrected annotation to `-> Tensor`.  
**Tested:** Function output shape verified; all call sites (`inference/me_infer.py`) already assigned to a single variable.

## 18. Cache repeated config-to-tensor conversions in InferenceModule setup
**File:** `inference/me_infer_module.py`  
**Smell:** `predict_step` and `test_step` called `torch.tensor(self.config.xxx).to(device)` on every batch — 3 times in predict, 4 times in test — for scalar config values that never change.  
**Fix:** Convert `d3pm_sample_ts_resolved`, `boundary_decoding_threshold`, `boundary_decoding_radius`, and `note_presence_threshold` to tensors once in `setup()` and store as instance attributes. Call sites use `.to(device)` on the cached tensors.  
**Tested:** Import and method source verification; `setup()` caches for both `predict` and `test` stages.

## 19. Extract `_PartAggregatingCallback` to eliminate duplicated counter-and-flush lifecycle
**File:** `inference/callbacks.py`  
**Smell:** `SaveCombinedFileCallback` and `UpdateDiffSingerTranscriptionsCallback` independently implemented identical state-machine logic: track per-key counters, increment per batch item, flush when all parts received, and epoch-end fallback for stragglers (~40 lines duplicated each).  
**Fix:** Extracted `_PartAggregatingCallback` ABC with four hooks: `_get_key`, `_get_total`, `_process_item`, `_flush_key`. Both callbacks now inherit from it and only implement the hooks specific to their data model.  
**Tested:** Instantiation of all 6 callback subclasses; hook resolution verified; inheritance chain intact for `SaveCombinedMidiFileCallback` and `SaveCombinedTextFileCallback`.
